### PR TITLE
Fix dialog closing

### DIFF
--- a/src/DialogHeader/DialogHeader.tsx
+++ b/src/DialogHeader/DialogHeader.tsx
@@ -1,5 +1,4 @@
 import DialogTitle from "@material-ui/core/DialogTitle";
-import IconButton from "@material-ui/core/IconButton";
 import Typography, { TypographyProps } from "@material-ui/core/Typography";
 import React from "react";
 
@@ -27,14 +26,14 @@ export const DialogHeader: React.FC<DialogHeaderProps> = ({
         <Typography variant="h5" component="h5" {...props}>
           {children}
         </Typography>
-        <IconButton
+        <button
           className={classes.button}
           onClick={onClose}
           aria-label="Close modal"
           data-test="close"
         >
           <CloseIcon />
-        </IconButton>
+        </button>
       </DialogTitle>
     </>
   );

--- a/src/DialogHeader/styles.ts
+++ b/src/DialogHeader/styles.ts
@@ -1,9 +1,18 @@
 import { makeStyles } from "../theme";
 
 export const useStyles = makeStyles(
-  () => ({
+  (theme) => ({
     button: {
-      opacity: 0.6,
+      "&:hover, &:focus": {
+        color: theme.palette.saleor.active[1],
+      },
+      appearance: "none",
+      border: "none",
+      background: "transparent",
+      color: theme.palette.saleor.main[3],
+      cursor: "pointer",
+      padding: 0,
+      outline: 0,
     },
     wrapper: {
       alignItems: "center",

--- a/stories/dialogs.stories.tsx
+++ b/stories/dialogs.stories.tsx
@@ -1,5 +1,4 @@
 import {
-  Button,
   Dialog,
   DialogActions,
   DialogContent,
@@ -12,7 +11,7 @@ import {
 import { Meta } from "@storybook/react";
 import React from "react";
 
-import { DialogHeader, DialogTable, ScrollShadow } from "../src";
+import { Button, DialogHeader, DialogTable, ScrollShadow } from "../src";
 import {
   isScrolledToBottom,
   isScrolledToTop,
@@ -30,7 +29,7 @@ export const Info: React.FC = () => (
       </DialogContentText>
     </DialogContent>
     <DialogActions>
-      <Button color="primary" variant="contained">
+      <Button color="primary" variant="primary">
         OK
       </Button>
     </DialogActions>
@@ -69,7 +68,7 @@ export const WithOverflowTable: React.FC = () => {
       </DialogTable>
       <ScrollShadow show={bottomShadow} variant="bottom">
         <DialogActions>
-          <Button color="primary" variant="contained">
+          <Button color="primary" variant="primary">
             OK
           </Button>
         </DialogActions>


### PR DESCRIPTION
This PR fixes dialog close icon, which had been broken in #59 

Screenshots:
<img width="686" alt="Zrzut ekranu 2021-10-15 o 11 27 41" src="https://user-images.githubusercontent.com/6833443/137466735-a4d9f7f3-b788-4547-8c59-7ccc845096bc.png">
<img width="715" alt="Zrzut ekranu 2021-10-15 o 11 35 06" src="https://user-images.githubusercontent.com/6833443/137466742-3b1c1097-85f4-4481-bf16-e87ad647f7df.png">
