### PR TITLE
Fix ThemeOptions types import

### DIFF
--- a/src/theme/createSaleorTheme/types.ts
+++ b/src/theme/createSaleorTheme/types.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/unified-signatures */
 import type { Theme } from "@material-ui/core/styles";
-import type { ThemeOptions } from "@material-ui/core/styles/createMuiTheme";
+import type { ThemeOptions } from "@material-ui/core/styles";
 import type {
   Palette,
   PaletteOptions,


### PR DESCRIPTION
Installing dependencies in development raises the exception below:

`(typescript) Error: /home/christ/Kreyet/macaw-ui/src/theme/createSaleorTheme/types.ts(3,35): semantic error TS2307: Cannot find module '@material-ui/core/styles/createMuiTheme' or its corresponding type declarations.`

Resolving the path to { ThemeOptions } fixes the issue on my side.