### PR TITLE
Add secondary icon button

### DIFF
--- a/src/IconButton/IconButton.tsx
+++ b/src/IconButton/IconButton.tsx
@@ -1,3 +1,4 @@
+import ButtonBase from "@material-ui/core/ButtonBase";
 import MuiIconButton, {
   IconButtonProps as MuiIconButtonProps,
 } from "@material-ui/core/IconButton";
@@ -11,14 +12,22 @@ export type IconButtonProps<T extends React.ElementType = "button"> = Omit<
   "variant"
 > & {
   error?: boolean;
+  variant?: "primary" | "secondary";
 };
 
 export const IconButton: React.FC<IconButtonProps> = ({
   className,
   error,
+  variant = "primary",
   ...props
 }) => {
   const classes = useStyles();
+
+  if (variant === "secondary") {
+    return (
+      <ButtonBase className={classes.secondary} disableRipple {...props} />
+    );
+  }
 
   return (
     <MuiIconButton

--- a/src/IconButton/styles.ts
+++ b/src/IconButton/styles.ts
@@ -22,6 +22,18 @@ const useStyles = makeStyles(
         color: theme.palette.saleor.errorAction[5],
       },
     },
+    secondary: {
+      "&:hover, &.Mui-focusVisible": {
+        color: theme.palette.primary.main,
+      },
+      "&:disabled": {
+        color: theme.palette.saleor.disabled,
+      },
+      color: theme.palette.saleor.main[3],
+      transition: theme.transitions.create("color", {
+        duration: theme.transitions.duration.shorter,
+      }),
+    },
   }),
   {
     name: "IconButton",

--- a/stories/buttons.stories.tsx
+++ b/stories/buttons.stories.tsx
@@ -63,6 +63,14 @@ export const Default: Story = () => {
               <Delete />
             </IconButton>
           </Cell>
+          <Cell>
+            <IconButton variant="secondary">
+              <Delete />
+            </IconButton>
+            <IconButton disabled variant="secondary">
+              <Delete />
+            </IconButton>
+          </Cell>
         </div>
         <div>
           <Cell>


### PR DESCRIPTION
This PR introduces secondary icon button, mostly used in lists as an action button.

Screenshot:
<img width="227" alt="Zrzut ekranu 2021-10-18 o 13 47 20" src="https://user-images.githubusercontent.com/6833443/137724592-ba2be521-453c-4770-812b-502ce0dbdbbf.png">
