### PR TITLE
Fix icon button and error input

### DIFF
--- a/src/IconButton/IconButton.tsx
+++ b/src/IconButton/IconButton.tsx
@@ -12,18 +12,21 @@ export type IconButtonProps<T extends React.ElementType = "button"> = Omit<
   "variant"
 > & {
   error?: boolean;
+  hoverOutline?: boolean;
   variant?: "primary" | "secondary";
 };
 
 export const IconButton: React.FC<IconButtonProps> = React.forwardRef(
-  ({ className, error, variant = "primary", ...props }, ref) => {
+  ({ className, error, hoverOutline, variant = "primary", ...props }, ref) => {
     const classes = useStyles();
 
     if (variant === "secondary") {
       return (
         <ButtonBase
           ref={ref}
-          className={clsx(classes.secondary, className)}
+          className={clsx(classes.secondary, className, {
+            [classes.hoverOutline]: hoverOutline,
+          })}
           disableRipple
           {...props}
         />

--- a/src/IconButton/styles.ts
+++ b/src/IconButton/styles.ts
@@ -29,10 +29,23 @@ const useStyles = makeStyles(
       "&:disabled": {
         color: theme.palette.saleor.disabled,
       },
+      background: "transparent",
+      borderRadius: 4,
       color: theme.palette.saleor.main[3],
-      transition: theme.transitions.create("color", {
+      padding: theme.spacing(0.5),
+      transition: theme.transitions.create(["color", "background"], {
         duration: theme.transitions.duration.shorter,
       }),
+    },
+    hoverOutline: {
+      "&$secondary": {
+        "&:hover,&:focus-visible": {
+          background: theme.palette.saleor.active[5],
+        },
+        "&:active": {
+          background: theme.palette.saleor.active[4],
+        },
+      },
     },
   }),
   {

--- a/src/theme/createSaleorTheme/overrides/inputs.ts
+++ b/src/theme/createSaleorTheme/overrides/inputs.ts
@@ -1,5 +1,9 @@
 import type { Overrides } from "@material-ui/core/styles/overrides";
 
+function getInputBoxShadow(color: string) {
+  return `0 0 0 3px ${color}`;
+}
+
 import { SaleorThemeColors } from "../types";
 
 export const inputOverrides = (colors: SaleorThemeColors): Overrides => ({
@@ -116,23 +120,24 @@ export const inputOverrides = (colors: SaleorThemeColors): Overrides => ({
       "&$error": {
         "&$focused": {
           "&:hover": {
-            boxShadow: `0px 0px 0px 3px ${colors.fail.mid}`,
+            boxShadow: getInputBoxShadow(colors.fail.mid),
           },
           "& fieldset": {
             borderColor: colors.fail.dark,
           },
-          boxShadow: `0px 0px 0px 3px ${colors.fail.mid}`,
+          boxShadow: getInputBoxShadow(colors.fail.mid),
         },
         "&:hover": {
           "&& fieldset": {
             borderColor: colors.fail.dark,
           },
-          boxShadow: `0px 0px 0px 3px ${colors.fail.light}`,
+          boxShadow: getInputBoxShadow(colors.fail.light),
         },
+        boxShadow: getInputBoxShadow(colors.fail.light),
       },
       "&$focused": {
         "&, &:hover": {
-          boxShadow: `0px 0px 0px 3px ${colors.active[3]}`,
+          boxShadow: getInputBoxShadow(colors.active[3]),
         },
         "& input": {
           "& fieldset": {
@@ -145,7 +150,7 @@ export const inputOverrides = (colors: SaleorThemeColors): Overrides => ({
         },
       },
       "&:hover": {
-        boxShadow: `0px 0px 0px 3px ${colors.active[5]}`,
+        boxShadow: getInputBoxShadow(colors.active[5]),
         "& input": {
           color: colors.font.default,
         },

--- a/stories/buttons.stories.tsx
+++ b/stories/buttons.stories.tsx
@@ -1,4 +1,4 @@
-import { Typography } from "@material-ui/core";
+import { FormControlLabel, Typography } from "@material-ui/core";
 import { Meta, Story } from "@storybook/react";
 import React from "react";
 import Delete from "@material-ui/icons/Delete";
@@ -64,9 +64,22 @@ export const Default: Story = () => {
             </IconButton>
           </Cell>
           <Cell>
-            <IconButton variant="secondary">
-              <Delete />
-            </IconButton>
+            <FormControlLabel
+              control={
+                <IconButton variant="secondary">
+                  <Delete />
+                </IconButton>
+              }
+              label="default"
+            />
+            <FormControlLabel
+              control={
+                <IconButton hoverOutline variant="secondary">
+                  <Delete />
+                </IconButton>
+              }
+              label="outlined"
+            />
             <IconButton disabled variant="secondary">
               <Delete />
             </IconButton>


### PR DESCRIPTION
This PR:
- sets outline in input's error state to be present not only if user is hovering over it
- adds optional outline to secondary icon button