### PR TITLE
Overridable buttons

### DIFF
--- a/src/Button/Button.tsx
+++ b/src/Button/Button.tsx
@@ -1,6 +1,8 @@
 import MuiButton, {
   ButtonProps as MuiButtonProps,
+  ButtonTypeMap as MuiButtonTypeMap,
 } from "@material-ui/core/Button";
+import { OverridableComponent } from "@material-ui/core/OverridableComponent";
 import clsx from "clsx";
 import React from "react";
 
@@ -8,13 +10,22 @@ import useStyles from "./styles";
 
 export type ButtonVariant = "primary" | "secondary" | "tertiary";
 
+interface ButtonInnerProps {
+  error?: boolean;
+  variant?: ButtonVariant;
+}
+
+export interface ButtonTypeMap<P = {}, D extends React.ElementType = "button"> {
+  props: Omit<MuiButtonTypeMap<P, D>["props"], "variant"> & ButtonInnerProps;
+  defaultComponent: D;
+  classKey: never;
+}
+
 export type ButtonProps<T extends React.ElementType = "button"> = Omit<
   MuiButtonProps<T>,
   "variant"
-> & {
-  error?: boolean;
-  variant?: ButtonVariant;
-};
+> &
+  ButtonInnerProps;
 
 function getButtonProps(variant: ButtonVariant): Partial<MuiButtonProps> {
   switch (variant) {
@@ -27,7 +38,7 @@ function getButtonProps(variant: ButtonVariant): Partial<MuiButtonProps> {
   }
 }
 
-export const Button: React.FC<ButtonProps> = ({
+const _Button: React.FC<ButtonProps> = ({
   className,
   error,
   variant = "tertiary",
@@ -56,4 +67,5 @@ export const Button: React.FC<ButtonProps> = ({
     />
   );
 };
-Button.displayName = "Button";
+_Button.displayName = "Button";
+export const Button = _Button as OverridableComponent<ButtonTypeMap>;

--- a/src/PillLink/PillLink.tsx
+++ b/src/PillLink/PillLink.tsx
@@ -1,19 +1,35 @@
+import {
+  OverridableComponent,
+  OverrideProps,
+} from "@material-ui/core/OverridableComponent";
 import clsx from "clsx";
 import React from "react";
 import { UserInteraction } from "../../types/utils";
-
 import useStyles from "./styles";
 
-export interface PillLinkProps
-  extends React.DetailedHTMLProps<
-    React.AnchorHTMLAttributes<HTMLAnchorElement>,
-    HTMLAnchorElement
-  > {
+export interface PillLinkInnerProps {
+  className?: string;
+  children?: React.ReactNode;
   state?: UserInteraction;
 }
+export interface PillLinkTypeMap<P = {}, D extends React.ElementType = "a"> {
+  props: P & PillLinkInnerProps;
+  classKey: never;
+  defaultComponent: D;
+}
 
-export const PillLink: React.FC<PillLinkProps> = ({
+export type PillLinkProps<
+  D extends React.ElementType = PillLinkTypeMap["defaultComponent"],
+  P = {}
+> = OverrideProps<PillLinkTypeMap<P, D>, D>;
+
+interface PillLinkPropsWithComponent extends PillLinkProps {
+  component?: React.ElementType;
+}
+
+const _PillLink: React.FC<PillLinkPropsWithComponent> = ({
   children,
+  component: Component = "a",
   className,
   state = "default",
   ...props
@@ -21,7 +37,7 @@ export const PillLink: React.FC<PillLinkProps> = ({
   const classes = useStyles();
 
   return (
-    <a
+    <Component
       className={clsx(classes.root, className, {
         [classes.hover]: state === "hover",
         [classes.active]: state === "active",
@@ -29,7 +45,8 @@ export const PillLink: React.FC<PillLinkProps> = ({
       {...props}
     >
       {children}
-    </a>
+    </Component>
   );
 };
-PillLink.displayName = "PillLink";
+_PillLink.displayName = "PillLink";
+export const PillLink = _PillLink as OverridableComponent<PillLinkTypeMap>;


### PR DESCRIPTION
This PR allows `<Button />` and `<PillLink />` to be overridden using `component` prop.