### PR TITLE
Add text color button variants

### DIFF
--- a/src/Button/Button.tsx
+++ b/src/Button/Button.tsx
@@ -9,14 +9,18 @@ import React from "react";
 import useStyles from "./styles";
 
 export type ButtonVariant = "primary" | "secondary" | "tertiary";
+// Aliasing "default" to "text" because "default" isn't actually default
+export type ButtonColor = "primary" | "secondary" | "text";
 
 interface ButtonInnerProps {
+  color?: ButtonColor;
   error?: boolean;
   variant?: ButtonVariant;
 }
 
 export interface ButtonTypeMap<P = {}, D extends React.ElementType = "button"> {
-  props: Omit<MuiButtonTypeMap<P, D>["props"], "variant"> & ButtonInnerProps;
+  props: Omit<MuiButtonTypeMap<P, D>["props"], "variant" | "color"> &
+    ButtonInnerProps;
   defaultComponent: D;
   classKey: never;
 }
@@ -27,19 +31,25 @@ export type ButtonProps<T extends React.ElementType = "button"> = Omit<
 > &
   ButtonInnerProps;
 
-function getButtonProps(variant: ButtonVariant): Partial<MuiButtonProps> {
+function getButtonProps(
+  colorProp: ButtonColor,
+  variant: ButtonVariant
+): Partial<MuiButtonProps> {
+  const color = colorProp === "text" ? "default" : colorProp;
+
   switch (variant) {
     case "primary":
-      return { variant: "contained", color: "primary" };
+      return { variant: "contained", color };
     case "secondary":
-      return { variant: "outlined", color: "primary" };
+      return { variant: "outlined", color };
     default:
-      return { variant: "text", color: "primary" };
+      return { variant: "text", color };
   }
 }
 
 const _Button: React.FC<ButtonProps> = ({
   className,
+  color = "primary",
   error,
   variant = "tertiary",
   ...props
@@ -61,7 +71,7 @@ const _Button: React.FC<ButtonProps> = ({
         [classes.tertiaryDisabled]:
           variant === "tertiary" && error && props.disabled,
       })}
-      {...getButtonProps(variant)}
+      {...getButtonProps(color, variant)}
       disableRipple
       {...props}
     />

--- a/src/theme/createSaleorTheme/overrides/buttons.ts
+++ b/src/theme/createSaleorTheme/overrides/buttons.ts
@@ -55,6 +55,12 @@ export const buttonOverrides = (colors: SaleorThemeColors): Overrides => {
         "&&$disabled": {
           color: colors.disabled,
         },
+        "&:hover, &$focusVisible": {
+          background: colors.main[5],
+        },
+        "&:active": {
+          background: colors.main[4],
+        },
       },
       textPrimary: {
         "&:hover, &$focusVisible": {
@@ -73,8 +79,22 @@ export const buttonOverrides = (colors: SaleorThemeColors): Overrides => {
           borderColor: colors.disabled,
           color: colors.disabled,
         },
+        "&:hover": {
+          // Unsets border as it will require us to override borderWidth and
+          // borderStyle over and over
+          border: undefined,
+        },
+        "&:hover, &$focusVisible": {
+          borderColor: colors.main[1],
+          backgroundColor: colors.main[5],
+        },
+        "&:active": {
+          backgroundColor: colors.main[4],
+        },
         background: colors.background.paper,
-        border: `2px solid ${colors.active[4]}`,
+        borderColor: colors.main[4],
+        borderWidth: 2,
+        borderStyle: "solid",
         // 2px smaller because of border
         padding: "10px 12px",
       },
@@ -92,6 +112,7 @@ export const buttonOverrides = (colors: SaleorThemeColors): Overrides => {
           backgroundColor: colors.active[4],
         },
         border: undefined,
+        borderColor: colors.active[4],
       },
     },
     MuiIconButton: {

--- a/src/theme/createSaleorTheme/types.ts
+++ b/src/theme/createSaleorTheme/types.ts
@@ -36,7 +36,7 @@ export type SaleorThemeColors = Record<
   alert: AlertColors;
   theme: ThemeType;
   fail: Record<"dark" | "mid" | "light", string>;
-  main: Record<1 | 2 | 3 | 4, string>;
+  main: Record<1 | 2 | 3 | 4 | 5, string>;
   active: Record<1 | 2 | 3 | 4 | 5, string>;
   errorAction: Record<1 | 2 | 3 | 4 | 5, string>;
 };

--- a/src/theme/themes.ts
+++ b/src/theme/themes.ts
@@ -54,6 +54,7 @@ export const dark: SaleorThemeColors = {
     2: "rgba(252, 252, 252, 0.8)",
     3: "rgba(252, 252, 252, 0.6)",
     4: "rgba(252, 252, 252, 0.4)",
+    5: "rgba(252, 252, 252, 0.1)",
   },
   fail: {
     dark: "#B65757",
@@ -127,6 +128,7 @@ export const light: SaleorThemeColors = {
     2: "rgba(40, 35, 74, 0.8)",
     3: "rgba(40, 35, 74, 0.6)",
     4: "rgba(40, 35, 74, 0.4)",
+    5: "rgba(40, 35, 74, 0.1)",
   },
   fail: {
     dark: "#B65757",

--- a/stories/buttons.stories.tsx
+++ b/stories/buttons.stories.tsx
@@ -54,10 +54,10 @@ const DefaultStory: React.FC = () => {
               Secondary
             </Button>
             <Button variant="secondary" color="text">
-              Secondary
+              Secondary Text
             </Button>
             <Button disabled variant="secondary" color="text">
-              Secondary
+              Secondary Text
             </Button>
           </Cell>
           <Cell>
@@ -73,10 +73,10 @@ const DefaultStory: React.FC = () => {
               Tertiary
             </Button>
             <Button variant="tertiary" color="text">
-              Tertiary
+              Tertiary Text
             </Button>
             <Button disabled variant="tertiary" color="text">
-              Tertiary
+              Tertiary Text
             </Button>
           </Cell>
           <Cell>

--- a/stories/buttons.stories.tsx
+++ b/stories/buttons.stories.tsx
@@ -38,6 +38,48 @@ const DefaultStory: React.FC = () => {
             </IconButton>
           </Cell>
           <Cell>
+            <PillLink href="#">Clickable Pill</PillLink>
+            <PillLink href="#" state="hover">
+              Clickable Pill
+            </PillLink>
+            <PillLink href="#" state="active">
+              Clickable Pill
+            </PillLink>
+          </Cell>
+        </div>
+        <div>
+          <Cell>
+            <Button variant="secondary">Secondary</Button>
+            <Button disabled variant="secondary">
+              Secondary
+            </Button>
+            <Button variant="secondary" color="text">
+              Secondary
+            </Button>
+            <Button disabled variant="secondary" color="text">
+              Secondary
+            </Button>
+          </Cell>
+          <Cell>
+            <LayoutButton>Layout</LayoutButton>
+            <LayoutButton state="hover">Layout</LayoutButton>
+            <LayoutButton state="active">Layout</LayoutButton>
+          </Cell>
+        </div>
+        <div>
+          <Cell>
+            <Button variant="tertiary">Tertiary</Button>
+            <Button disabled variant="tertiary">
+              Tertiary
+            </Button>
+            <Button variant="tertiary" color="text">
+              Tertiary
+            </Button>
+            <Button disabled variant="tertiary" color="text">
+              Tertiary
+            </Button>
+          </Cell>
+          <Cell>
             <FormControlLabel
               control={
                 <IconButton variant="secondary">
@@ -57,36 +99,6 @@ const DefaultStory: React.FC = () => {
             <IconButton disabled variant="secondary">
               <Delete />
             </IconButton>
-          </Cell>
-        </div>
-        <div>
-          <Cell>
-            <Button variant="secondary">Secondary</Button>
-            <Button disabled variant="secondary">
-              Secondary
-            </Button>
-          </Cell>
-          <Cell>
-            <PillLink href="#">Clickable Pill</PillLink>
-            <PillLink href="#" state="hover">
-              Clickable Pill
-            </PillLink>
-            <PillLink href="#" state="active">
-              Clickable Pill
-            </PillLink>
-          </Cell>
-        </div>
-        <div>
-          <Cell>
-            <Button variant="tertiary">Tertiary</Button>
-            <Button disabled variant="tertiary">
-              Tertiary
-            </Button>
-          </Cell>
-          <Cell>
-            <LayoutButton>Layout</LayoutButton>
-            <LayoutButton state="hover">Layout</LayoutButton>
-            <LayoutButton state="active">Layout</LayoutButton>
           </Cell>
         </div>
       </div>


### PR DESCRIPTION
This PR adds `color="text"` prop to Button component.

Screenshot:
<img width="637" alt="Zrzut ekranu 2021-11-19 o 15 14 50" src="https://user-images.githubusercontent.com/6833443/142636920-cbf03f51-e855-4914-81e1-953371f3affb.png">
