### PR TITLE
Add disabled prop to tooltip

### DIFF
--- a/src/Tooltip/Tooltip.tsx
+++ b/src/Tooltip/Tooltip.tsx
@@ -6,16 +6,20 @@ import useStyles from "./styles";
 
 export interface TooltipProps extends MUITooltipProps {
   variant?: "info" | "success" | "warning" | "error";
+  disabled?: boolean;
 }
 
 export const Tooltip: React.FC<TooltipProps> = ({
   children,
+  disabled = false,
   variant = "info",
   ...rest
 }) => {
   const classes = useStyles({ variant, children, ...rest });
 
-  return (
+  return disabled ? (
+    children
+  ) : (
     <MUITooltip classes={classes} {...rest}>
       {children}
     </MUITooltip>


### PR DESCRIPTION
I want to merge this change because it adds `disabled` prop to Tooltip component.

Often Tooltip is rendered conditionally:
```
condition
? <Tooltip><Element /></Tooltip>
: <Element />
```
This is difficult to read when `<Element />` has a lot of props. Adding `disabled` prop will result in easier syntax:
```
<Tooltip disabled={condition}>
    <Element />
</Tooltip>
```