### PR TITLE
Do not dock savebar if not scrolled to bottom

### DIFF
--- a/src/ActionBar/ActionBar.tsx
+++ b/src/ActionBar/ActionBar.tsx
@@ -14,7 +14,6 @@ import useStyles from "./styles";
 export interface ActionBarProps {
   disabled: boolean;
   state: ConfirmButtonTransitionState;
-  fixed?: boolean;
   className?: string;
   children: React.ReactNode[] | React.ReactNode;
 }
@@ -23,7 +22,6 @@ export const ActionBar: React.FC<ActionBarProps> = ({
   disabled,
   children,
   state,
-  fixed,
   className,
   ...rest
 }) => {
@@ -42,16 +40,7 @@ export const ActionBar: React.FC<ActionBarProps> = ({
 
   return (
     <Portal container={anchor.current}>
-      <div
-        className={clsx(
-          classes.root,
-          {
-            [classes.fixed]: fixed,
-          },
-          className
-        )}
-        {...rest}
-      >
+      <div className={clsx(classes.root, className)} {...rest}>
         <Container maxWidth="lg">
           <Card
             className={clsx(classes.paper, {

--- a/src/ActionBar/ActionBar.tsx
+++ b/src/ActionBar/ActionBar.tsx
@@ -30,15 +30,8 @@ export const ActionBar: React.FC<ActionBarProps> = ({
   const { ssr } = useTheme();
   const classes = useStyles();
 
-  const { anchor, docked, setDocked } = useActionBar();
+  const { anchor } = useActionBar();
   const scrollPosition = useWindowScroll();
-
-  React.useEffect(() => {
-    if (!disabled && state !== "loading") {
-      setDocked(false);
-    }
-  }, [disabled, state, setDocked]);
-  React.useEffect(() => () => setDocked(true), [setDocked]);
 
   const scrolledToBottom =
     scrollPosition.y + window.innerHeight >= document.body.scrollHeight;
@@ -62,7 +55,7 @@ export const ActionBar: React.FC<ActionBarProps> = ({
         <Container maxWidth="lg">
           <Card
             className={clsx(classes.paper, {
-              [classes.shadow]: !(docked || scrolledToBottom),
+              [classes.shadow]: !scrolledToBottom,
             })}
           >
             <CardContent className={classes.content}>{children}</CardContent>

--- a/src/ActionBar/context.tsx
+++ b/src/ActionBar/context.tsx
@@ -2,8 +2,6 @@ import React from "react";
 
 export interface ActionBarContextType {
   anchor: React.RefObject<HTMLDivElement>;
-  docked: boolean;
-  setDocked: (docked: boolean) => void;
 }
 
 export const ActionBarContext = React.createContext<
@@ -21,11 +19,10 @@ export const useActionBar = () => {
 };
 
 export const ActionBarProvider: React.FC = ({ children }) => {
-  const [docked, setDocked] = React.useState(true);
   const anchor = React.useRef<HTMLDivElement | null>(null);
 
   return (
-    <ActionBarContext.Provider value={{ anchor, docked, setDocked }}>
+    <ActionBarContext.Provider value={{ anchor }}>
       {children}
     </ActionBarContext.Provider>
   );

--- a/src/ActionBar/styles.ts
+++ b/src/ActionBar/styles.ts
@@ -24,11 +24,6 @@ const useStyles = makeStyles(
     shadow: {
       boxShadow: "0 -24px 20px -20px rgba(0, 0, 0, 0.15)",
     },
-    fixed: {
-      position: "fixed",
-      bottom: 0,
-      width: "100%",
-    },
   }),
   { name: "ActionBar" }
 );

--- a/src/Savebar/Savebar.tsx
+++ b/src/Savebar/Savebar.tsx
@@ -20,7 +20,6 @@ export interface SavebarProps {
   state: ConfirmButtonTransitionState;
   labels: SavebarLabels;
   tooltips?: SavebarTooltips;
-  fixed?: boolean;
   className?: string;
   onCancel: () => void;
   onDelete?: () => void;
@@ -32,7 +31,6 @@ export const Savebar: React.FC<SavebarProps> = ({
   labels,
   tooltips,
   state,
-  fixed,
   className,
   onCancel,
   onDelete,
@@ -41,12 +39,7 @@ export const Savebar: React.FC<SavebarProps> = ({
   const classes = useStyles();
 
   return (
-    <ActionBar
-      state={state}
-      disabled={disabled}
-      fixed={fixed}
-      className={className}
-    >
+    <ActionBar state={state} disabled={disabled} className={className}>
       {!!onDelete && (
         <ButtonTooltipDecorator tooltip={tooltips?.delete}>
           <Button

--- a/src/Savebar/Savebar.tsx
+++ b/src/Savebar/Savebar.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 
 import { Button } from "..";
-import { useActionBar } from "../ActionBar";
 import { ActionBar } from "../ActionBar/ActionBar";
 import {
   ConfirmButton,
@@ -40,7 +39,6 @@ export const Savebar: React.FC<SavebarProps> = ({
   onSubmit,
 }) => {
   const classes = useStyles();
-  const { setDocked } = useActionBar();
 
   return (
     <ActionBar
@@ -79,7 +77,6 @@ export const Savebar: React.FC<SavebarProps> = ({
           onClick={onSubmit}
           transitionState={state}
           data-test="button-bar-confirm"
-          onTransitionToDefault={() => setDocked(true)}
         />
       </ButtonTooltipDecorator>
     </ActionBar>


### PR DESCRIPTION
This PR removes savebar's ability to dock at the bottom of the page (not screen) if nothing has changed in form.