### PR TITLE
Fix switch placement in FormControlLabel

### DIFF
--- a/src/theme/createSaleorTheme/overrides/controls.ts
+++ b/src/theme/createSaleorTheme/overrides/controls.ts
@@ -137,7 +137,8 @@ export const controlOverrides = (
         },
       },
       height: 48,
-      width: 72,
+      padding: "12px 16px",
+      width: 80,
     },
     switchBase: {
       "&$checked": {
@@ -157,6 +158,8 @@ export const controlOverrides = (
     thumb: {
       boxShadow: "none",
       height: 14,
+      left: 4,
+      position: "relative",
       width: 14,
     },
     track: {

--- a/stories/controls.stories.tsx
+++ b/stories/controls.stories.tsx
@@ -1,5 +1,6 @@
 import {
   Checkbox,
+  FormControlLabel,
   Radio,
   RadioGroup,
   Switch,

--- a/stories/controls.stories.tsx
+++ b/stories/controls.stories.tsx
@@ -1,6 +1,5 @@
 import {
   Checkbox,
-  FormControlLabel,
   Radio,
   RadioGroup,
   Switch,


### PR DESCRIPTION
This PR fixes switch placement when used in `<FormControlLabel control={Switch} />`, resulting in occasional clipping.

### Screenshots
![image (19)](https://user-images.githubusercontent.com/6833443/157860942-d1157f29-9b13-4f9f-9fec-2b541cf4c1a5.png)
<img width="103" alt="Zrzut ekranu 2022-03-11 o 12 45 04" src="https://user-images.githubusercontent.com/6833443/157860953-3e1a5e3f-7e7c-4209-a0ad-cc7bc258b714.png">

