### PR TITLE
Fix IconButton state prop

### DIFF
--- a/src/IconButton/IconButton.tsx
+++ b/src/IconButton/IconButton.tsx
@@ -38,8 +38,10 @@ export const IconButton: React.FC<IconButtonProps> = React.forwardRef(
           ref={ref}
           className={clsx(classes.secondary, className, {
             [classes.hoverOutline]: hoverOutline && !props.disabled,
-            [classes.hover]: state === "hover",
-            [classes.active]: state === "active",
+            [classes.hover]: state === "hover" && !props.disabled,
+            [classes.active]: state === "active" && !props.disabled,
+            [classes.error]: error,
+            [classes.disabledError]: error && props.disabled,
           })}
           disableRipple
           {...props}
@@ -50,11 +52,11 @@ export const IconButton: React.FC<IconButtonProps> = React.forwardRef(
     return (
       <MuiIconButton
         ref={ref}
-        className={clsx(className, {
+        className={clsx(classes.primary, className, {
+          [classes.hover]: state === "hover" && !props.disabled,
+          [classes.active]: state === "active" && !props.disabled,
           [classes.error]: error,
           [classes.disabledError]: error && props.disabled,
-          [classes.hover]: state === "hover",
-          [classes.active]: state === "active",
         })}
         disableRipple
         {...props}

--- a/src/IconButton/styles.ts
+++ b/src/IconButton/styles.ts
@@ -3,24 +3,14 @@ import { getSecondaryButtonStyles } from "./partials";
 
 const useStyles = makeStyles(
   (theme) => ({
-    error: {
-      "&&": {
-        "&:hover, &.Mui-focusVisible, &$hover": {
-          borderColor: theme.palette.saleor.errorAction[1],
-          color: theme.palette.saleor.errorAction[1],
-        },
-        "&:active, &$active": {
-          background: theme.palette.saleor.errorAction[5],
-        },
+    primary: {
+      "&:hover, &.Mui-focusVisible, &$hover, &$active": {
+        color: theme.palette.saleor.active[1],
+        borderColor: theme.palette.saleor.active[1],
       },
-      borderColor: theme.palette.saleor.errorAction[4],
-      color: theme.palette.saleor.errorAction[2],
-    },
-    disabledError: {
-      "&&&": {
-        borderColor: "transparent",
-        color: theme.palette.saleor.errorAction[5],
-      },
+      "&:active, &$active": {
+        background: theme.palette.saleor.active[5],
+      }
     },
     secondary: getSecondaryButtonStyles(theme.palette.saleor),
     hoverOutline: {
@@ -32,6 +22,37 @@ const useStyles = makeStyles(
         "&:active, &$active": {
           background: theme.palette.saleor.active[4],
         },
+      },
+    },
+    error: {
+      "&&&": {
+        
+        "&:hover, &.Mui-focusVisible, &$hover": {
+          borderColor: theme.palette.saleor.errorAction[1],
+          color: theme.palette.saleor.errorAction[1],
+        },
+        "&:active, &$active": {
+          background: theme.palette.saleor.errorAction[5],
+          color: theme.palette.saleor.errorAction[1],
+          borderColor: theme.palette.saleor.errorAction[2],
+        },
+        "&$secondary" : {
+          "&:hover, &.Mui-focusVisible, &$hover": {
+            background: theme.palette.saleor.errorAction[5],
+          },
+          "&:active, &$active": {
+            background: theme.palette.saleor.errorAction[4],
+            color: theme.palette.saleor.errorAction[1],
+          },
+        }
+      },
+      
+      color: theme.palette.saleor.errorAction[2],
+    },
+    disabledError: {
+      "&&&": {
+        borderColor: "transparent",
+        color: theme.palette.saleor.errorAction[5],
       },
     },
     active: {},

--- a/src/utils/guideStyles.ts
+++ b/src/utils/guideStyles.ts
@@ -38,6 +38,11 @@ const useStyles = makeStyles(
       padding: theme.spacing(3),
       rowGap: theme.spacing(3),
     },
+    gridCell: {
+      display: "grid",
+      gridTemplateColumns: "repeat(3, 1fr)",
+      gap: theme.spacing(3),
+    }
   }),
   { name: "Guide" }
 );

--- a/stories/buttons.stories.tsx
+++ b/stories/buttons.stories.tsx
@@ -3,7 +3,14 @@ import { ArrowDownward } from "@material-ui/icons";
 import { Meta, Story } from "@storybook/react";
 import React from "react";
 
-import { Button, DeleteIcon, IconButton, LayoutButton, PillLink } from "../src";
+import {
+  Button,
+  DeleteIcon,
+  EditIcon,
+  IconButton,
+  LayoutButton,
+  PillLink,
+} from "../src";
 import { Decorator, GuideDecorator } from "../src/utils/Decorator";
 import useGuideStyles from "../src/utils/guideStyles";
 import { Cell } from "./utils/Cell";
@@ -30,12 +37,26 @@ const DefaultStory: React.FC = () => {
             </Button>
           </Cell>
           <Cell>
-            <IconButton>
-              <DeleteIcon />
-            </IconButton>
-            <IconButton disabled>
-              <DeleteIcon />
-            </IconButton>
+            <div className={guideClasses.gridCell}>
+              <IconButton variant="primary">
+                <DeleteIcon />
+              </IconButton>
+              <IconButton variant="secondary">
+                <DeleteIcon />
+              </IconButton>
+              <IconButton disabled>
+                <DeleteIcon />
+              </IconButton>
+              <IconButton variant="primary" error>
+                <DeleteIcon />
+              </IconButton>
+              <IconButton variant="secondary" error>
+                <DeleteIcon />
+              </IconButton>
+              <IconButton disabled error>
+                <DeleteIcon />
+              </IconButton>
+            </div>
           </Cell>
           <Cell>
             <PillLink href="#">Clickable Pill</PillLink>

--- a/stories/buttons.stories.tsx
+++ b/stories/buttons.stories.tsx
@@ -3,13 +3,7 @@ import { ArrowDownward } from "@material-ui/icons";
 import { Meta, Story } from "@storybook/react";
 import React from "react";
 
-import {
-  Button,
-  DeleteIcon,
-  IconButton,
-  LayoutButton,
-  PillLink,
-} from "../src";
+import { Button, DeleteIcon, IconButton, LayoutButton, PillLink } from "../src";
 import { Decorator, GuideDecorator } from "../src/utils/Decorator";
 import useGuideStyles from "../src/utils/guideStyles";
 import { Cell } from "./utils/Cell";
@@ -46,13 +40,22 @@ const DefaultStory: React.FC = () => {
               <IconButton disabled>
                 <DeleteIcon />
               </IconButton>
-              <IconButton variant="primary" error>
+              <IconButton variant="primary" state="hover">
                 <DeleteIcon />
               </IconButton>
-              <IconButton variant="secondary" error>
+              <IconButton variant="secondary" state="hover">
                 <DeleteIcon />
               </IconButton>
-              <IconButton disabled error>
+              <IconButton disabled state="hover">
+                <DeleteIcon />
+              </IconButton>
+              <IconButton variant="primary" state="active">
+                <DeleteIcon />
+              </IconButton>
+              <IconButton variant="secondary" state="active">
+                <DeleteIcon />
+              </IconButton>
+              <IconButton disabled state="active">
                 <DeleteIcon />
               </IconButton>
             </div>
@@ -188,12 +191,35 @@ const ErrorStory: React.FC = () => {
             </Button>
           </Cell>
           <Cell>
-            <IconButton error>
-              <DeleteIcon />
-            </IconButton>
-            <IconButton error disabled>
-              <DeleteIcon />
-            </IconButton>
+            <div className={guideClasses.gridCell}>
+              <IconButton error variant="primary">
+                <DeleteIcon />
+              </IconButton>
+              <IconButton error variant="secondary">
+                <DeleteIcon />
+              </IconButton>
+              <IconButton error disabled>
+                <DeleteIcon />
+              </IconButton>
+              <IconButton error variant="primary" state="hover">
+                <DeleteIcon />
+              </IconButton>
+              <IconButton error variant="secondary" state="hover">
+                <DeleteIcon />
+              </IconButton>
+              <IconButton error disabled state="hover">
+                <DeleteIcon />
+              </IconButton>
+              <IconButton error variant="primary" state="active">
+                <DeleteIcon />
+              </IconButton>
+              <IconButton error variant="secondary" state="active">
+                <DeleteIcon />
+              </IconButton>
+              <IconButton error disabled state="active">
+                <DeleteIcon />
+              </IconButton>
+            </div>
           </Cell>
         </div>
         <div>

--- a/stories/buttons.stories.tsx
+++ b/stories/buttons.stories.tsx
@@ -6,7 +6,6 @@ import React from "react";
 import {
   Button,
   DeleteIcon,
-  EditIcon,
   IconButton,
   LayoutButton,
   PillLink,


### PR DESCRIPTION
IconButtons didn't apply correct styling when `state` prop was provided. This PR fixes the problem.

![image](https://user-images.githubusercontent.com/41952692/159917853-e3b34b55-73c5-4c14-94f5-a6fdbc715c3b.png)
![image](https://user-images.githubusercontent.com/41952692/159917869-f55e972f-c34d-4d86-b2ec-0004e6027961.png)

