### PR TITLE
Change Sidebar and SidebarDrawer to allow custom Link component

### DIFF
--- a/src/IconButton/styles.ts
+++ b/src/IconButton/styles.ts
@@ -10,7 +10,7 @@ const useStyles = makeStyles(
       },
       "&:active, &$active": {
         background: theme.palette.saleor.active[5],
-      }
+      },
     },
     secondary: getSecondaryButtonStyles(theme.palette.saleor),
     hoverOutline: {
@@ -26,7 +26,6 @@ const useStyles = makeStyles(
     },
     error: {
       "&&&": {
-        
         "&:hover, &.Mui-focusVisible, &$hover": {
           borderColor: theme.palette.saleor.errorAction[1],
           color: theme.palette.saleor.errorAction[1],
@@ -36,7 +35,7 @@ const useStyles = makeStyles(
           color: theme.palette.saleor.errorAction[1],
           borderColor: theme.palette.saleor.errorAction[2],
         },
-        "&$secondary" : {
+        "&$secondary": {
           "&:hover, &.Mui-focusVisible, &$hover": {
             background: theme.palette.saleor.errorAction[5],
           },
@@ -44,9 +43,9 @@ const useStyles = makeStyles(
             background: theme.palette.saleor.errorAction[4],
             color: theme.palette.saleor.errorAction[1],
           },
-        }
+        },
       },
-      
+
       color: theme.palette.saleor.errorAction[2],
     },
     disabledError: {

--- a/src/Sidebar/MenuItem.tsx
+++ b/src/Sidebar/MenuItem.tsx
@@ -174,9 +174,7 @@ export const MenuItem: React.FC<MenuItemProps> = ({
     }
   };
 
-  const RootNavComponent = menuItem.children
-    ? "div"
-    : linkComponent ?? "button";
+  const RootNavComponent = menuItem.children ? "div" : linkComponent ?? "div";
 
   return (
     <RootNavComponent

--- a/src/Sidebar/MenuItem.tsx
+++ b/src/Sidebar/MenuItem.tsx
@@ -157,7 +157,9 @@ export const MenuItem: React.FC<MenuItemProps> = ({
     }
   };
 
-  const RootNavComponent = menuItem.children ? "div" : linkComponent ?? "a";
+  const RootNavComponent = menuItem.children
+    ? "div"
+    : linkComponent ?? "button";
 
   return (
     <RootNavComponent

--- a/src/Sidebar/MenuItem.tsx
+++ b/src/Sidebar/MenuItem.tsx
@@ -12,13 +12,23 @@ import { makeStyles } from "../theme";
 import { CustomLinkComponent, SidebarMenuItem } from "./types";
 import { getLinkComponent, getLinkProps } from "./utils";
 
-export interface MenuItemProps {
+export interface MenuItemCommonProps {
   activeId: string;
   isMenuShrunk: boolean;
   menuItem: SidebarMenuItem;
-  onClick: (menuItem: SidebarMenuItem) => void;
-  linkComponent?: CustomLinkComponent;
 }
+
+export type MenuItemProps = MenuItemCommonProps &
+  (
+    | {
+        onClick: (menuItem: SidebarMenuItem) => void;
+        linkComponent?: never;
+      }
+    | {
+        onClick?: never;
+        linkComponent: CustomLinkComponent;
+      }
+  );
 
 export const menuWidth = 210;
 export const shrunkMenuWidth = 72;
@@ -152,7 +162,14 @@ export const MenuItem: React.FC<MenuItemProps> = ({
     if (menuItem.children) {
       setOpen(true);
     } else {
-      onClick(menuItem);
+      if (onClick) {
+        onClick(menuItem);
+      }
+
+      if (menuItem.onClick) {
+        menuItem.onClick();
+      }
+
       setOpen(false);
     }
   };

--- a/src/Sidebar/MenuItem.tsx
+++ b/src/Sidebar/MenuItem.tsx
@@ -9,13 +9,15 @@ import React from "react";
 import SVG from "react-inlinesvg";
 
 import { makeStyles } from "../theme";
-import { SidebarMenuItem } from "./types";
+import { CustomLinkComponent, SidebarMenuItem } from "./types";
+import { getLinkComponent, getLinkProps } from "./utils";
 
 export interface MenuItemProps {
   activeId: string;
   isMenuShrunk: boolean;
   menuItem: SidebarMenuItem;
   onClick: (menuItem: SidebarMenuItem) => void;
+  linkComponent?: CustomLinkComponent;
 }
 
 export const menuWidth = 210;
@@ -139,10 +141,11 @@ export const MenuItem: React.FC<MenuItemProps> = ({
   menuItem,
   isMenuShrunk,
   onClick,
+  linkComponent,
 }) => {
   const classes = useStyles({});
   const [open, setOpen] = React.useState(false);
-  const anchor = React.useRef<HTMLDivElement>(null);
+  const anchor = React.useRef<any>(null);
 
   const handleClick = (event: React.MouseEvent, menuItem: SidebarMenuItem) => {
     event.stopPropagation();
@@ -154,8 +157,10 @@ export const MenuItem: React.FC<MenuItemProps> = ({
     }
   };
 
+  const RootNavComponent = menuItem.children ? "div" : linkComponent ?? "a";
+
   return (
-    <div
+    <RootNavComponent
       className={clsx(classes.root, {
         [classes.rootOpen]: open,
         [classes.rootActive]: [
@@ -165,9 +170,10 @@ export const MenuItem: React.FC<MenuItemProps> = ({
         [classes.rootExpanded]: !isMenuShrunk,
       })}
       ref={anchor}
-      onClick={(event) => handleClick(event, menuItem)}
+      onClick={(event: React.MouseEvent) => handleClick(event, menuItem)}
+      {...getLinkProps(menuItem)}
     >
-      <button
+      <span
         className={classes.menuItemBtn}
         data-test="menu-item-label"
         data-test-id={menuItem.id}
@@ -184,7 +190,7 @@ export const MenuItem: React.FC<MenuItemProps> = ({
         >
           {menuItem.label}
         </Typography>
-      </button>
+      </span>
       {menuItem.children && (
         <Popper
           className={clsx(classes.popper, {
@@ -199,14 +205,12 @@ export const MenuItem: React.FC<MenuItemProps> = ({
             <Paper className={classes.paper}>
               {menuItem.children.map((subMenuItem) => {
                 if (subMenuItem.url || subMenuItem.children) {
-                  const linkProps = subMenuItem.external
-                    ? { href: subMenuItem.url, target: "_blank" }
-                    : {};
+                  const linkProps = getLinkProps(subMenuItem);
 
                   return (
                     <MuiMenuItem
                       aria-label={subMenuItem.ariaLabel}
-                      component={subMenuItem.external ? "a" : "button"}
+                      component={getLinkComponent(subMenuItem, linkComponent)}
                       className={clsx(classes.label, classes.subMenuLabel)}
                       key={subMenuItem.url}
                       onClick={(event: React.MouseEvent) =>
@@ -236,7 +240,7 @@ export const MenuItem: React.FC<MenuItemProps> = ({
           </ClickAwayListener>
         </Popper>
       )}
-    </div>
+    </RootNavComponent>
   );
 };
 

--- a/src/Sidebar/Sidebar.tsx
+++ b/src/Sidebar/Sidebar.tsx
@@ -23,7 +23,9 @@ const useStyles = makeStyles(
       paddingBottom: theme.spacing(3),
     },
     logo: {
+      display: "block",
       margin: `36px 0 ${theme.spacing(3)} ${theme.spacing(2.5)}`,
+      color: "inherit",
     },
     root: {
       transition: "width 0.5s ease",
@@ -50,6 +52,8 @@ export const Sidebar: React.FC<SidebarProps> = ({
   menuItems,
   toolbar,
   onMenuItemClick,
+  logoHref,
+  linkComponent,
 }) => {
   const classes = useStyles({});
   const { value: isShrunkStr, setValue: setShrink } = useLocalStorage(
@@ -59,6 +63,8 @@ export const Sidebar: React.FC<SidebarProps> = ({
   const isShrunk = isShrunkStr === "true";
   const { themeType } = useTheme();
 
+  const Link = linkComponent ?? "a";
+
   return (
     <div
       className={clsx(classes.root, {
@@ -66,9 +72,9 @@ export const Sidebar: React.FC<SidebarProps> = ({
       })}
     >
       <div className={classes.float}>
-        <div className={classes.logo}>
+        <Link href={logoHref} className={classes.logo}>
           {themeType === "dark" ? <LogoDark /> : <Logo />}
-        </div>
+        </Link>
         {menuItems.map((menuItem) => (
           <MenuItem
             activeId={activeId}
@@ -76,6 +82,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
             menuItem={menuItem}
             onClick={onMenuItemClick}
             key={menuItem.ariaLabel}
+            linkComponent={linkComponent}
           />
         ))}
         {toolbar && <div className={classes.toolbarContainer}>{toolbar}</div>}

--- a/src/Sidebar/Sidebar.tsx
+++ b/src/Sidebar/Sidebar.tsx
@@ -75,16 +75,25 @@ export const Sidebar: React.FC<SidebarProps> = ({
         <Link href={logoHref} className={classes.logo}>
           {themeType === "dark" ? <LogoDark /> : <Logo />}
         </Link>
-        {menuItems.map((menuItem) => (
-          <MenuItem
-            activeId={activeId}
-            isMenuShrunk={isShrunk}
-            menuItem={menuItem}
-            onClick={onMenuItemClick}
-            key={menuItem.ariaLabel}
-            linkComponent={linkComponent}
-          />
-        ))}
+        {menuItems.map((menuItem) =>
+          linkComponent ? (
+            <MenuItem
+              activeId={activeId}
+              isMenuShrunk={isShrunk}
+              menuItem={menuItem}
+              key={menuItem.ariaLabel}
+              linkComponent={linkComponent}
+            />
+          ) : (
+            <MenuItem
+              activeId={activeId}
+              isMenuShrunk={isShrunk}
+              menuItem={menuItem}
+              onClick={onMenuItemClick}
+              key={menuItem.ariaLabel}
+            />
+          )
+        )}
         {toolbar && <div className={classes.toolbarContainer}>{toolbar}</div>}
         <ExpandButton
           className={classes.expandButton}

--- a/src/Sidebar/types.ts
+++ b/src/Sidebar/types.ts
@@ -8,11 +8,20 @@ export interface SidebarMenuItem {
   iconSrc?: string;
   url?: string;
   external?: boolean;
+  isButton?: boolean;
 }
+
+export type CustomLinkComponent = React.ForwardRefExoticComponent<{
+  href?: string;
+  onClick?: (...params: any) => void;
+  className?: string;
+}>;
 
 export interface BaseSidebarProps {
   className?: string;
   menuItems: SidebarMenuItem[];
   toolbar?: React.ReactNode;
   onMenuItemClick: (menuItem: SidebarMenuItem) => void;
+  linkComponent?: CustomLinkComponent;
+  logoHref?: string;
 }

--- a/src/Sidebar/types.ts
+++ b/src/Sidebar/types.ts
@@ -8,6 +8,7 @@ export interface SidebarMenuItem {
   iconSrc?: string;
   url?: string;
   external?: boolean;
+  onClick?: () => void;
 }
 
 export type CustomLinkComponent = React.ForwardRefExoticComponent<{

--- a/src/Sidebar/types.ts
+++ b/src/Sidebar/types.ts
@@ -8,7 +8,6 @@ export interface SidebarMenuItem {
   iconSrc?: string;
   url?: string;
   external?: boolean;
-  isButton?: boolean;
 }
 
 export type CustomLinkComponent = React.ForwardRefExoticComponent<{

--- a/src/Sidebar/utils.ts
+++ b/src/Sidebar/utils.ts
@@ -1,0 +1,26 @@
+import { CustomLinkComponent, SidebarMenuItem } from "./types";
+
+export const getLinkProps = (menuItem: SidebarMenuItem) => {
+  if (menuItem.isButton || !menuItem.url) {
+    return {};
+  }
+  if (menuItem.external) {
+    return { href: menuItem.url, target: "_blank" };
+  }
+  return {
+    href: menuItem.url,
+  };
+};
+
+export const getLinkComponent = (
+  menuItem: SidebarMenuItem,
+  customComponent?: CustomLinkComponent
+) => {
+  if (menuItem.isButton || !menuItem.url) {
+    return "button";
+  }
+  if (menuItem.external) {
+    return "a";
+  }
+  return customComponent ?? "a";
+};

--- a/src/Sidebar/utils.ts
+++ b/src/Sidebar/utils.ts
@@ -1,26 +1,23 @@
 import { CustomLinkComponent, SidebarMenuItem } from "./types";
 
 export const getLinkProps = (menuItem: SidebarMenuItem) => {
-  if (menuItem.isButton || !menuItem.url) {
-    return {};
-  }
   if (menuItem.external) {
     return { href: menuItem.url, target: "_blank" };
   }
-  return {
-    href: menuItem.url,
-  };
+  if (menuItem.url) {
+    return {
+      href: menuItem.url,
+    };
+  }
+  return {};
 };
 
 export const getLinkComponent = (
   menuItem: SidebarMenuItem,
   customComponent?: CustomLinkComponent
 ) => {
-  if (menuItem.isButton || !menuItem.url) {
-    return "button";
-  }
   if (menuItem.external) {
     return "a";
   }
-  return customComponent ?? "a";
+  return customComponent ?? "button";
 };

--- a/src/SidebarDrawer/MenuItemBtn.tsx
+++ b/src/SidebarDrawer/MenuItemBtn.tsx
@@ -2,22 +2,24 @@ import Typography from "@material-ui/core/Typography";
 import React from "react";
 import SVG from "react-inlinesvg";
 
-import { SidebarMenuItem } from "../Sidebar/types";
+import { CustomLinkComponent, SidebarMenuItem } from "../Sidebar/types";
+import { getLinkComponent, getLinkProps } from "../Sidebar/utils";
 import useStyles from "./styles";
 
 export interface MenuItemBtnProps {
   menuItem: SidebarMenuItem;
   onClick: (menuItem: SidebarMenuItem) => void;
+  linkComponent?: CustomLinkComponent;
 }
+
 export const MenuItemBtn: React.FC<MenuItemBtnProps> = ({
   menuItem,
   onClick,
+  linkComponent,
 }) => {
   const classes = useStyles();
-  const linkProps = menuItem.external
-    ? { href: menuItem.url, target: "_blank" }
-    : {};
-  const Component = menuItem.external ? "a" : "button";
+  const linkProps = getLinkProps(menuItem);
+  const Component = getLinkComponent(menuItem, linkComponent);
 
   return (
     <Component
@@ -30,7 +32,11 @@ export const MenuItemBtn: React.FC<MenuItemBtnProps> = ({
       {menuItem.iconSrc && (
         <SVG className={classes.icon} src={menuItem.iconSrc} />
       )}
-      <Typography aria-label={menuItem.ariaLabel} className={classes.label}>
+      <Typography
+        component="span"
+        aria-label={menuItem.ariaLabel}
+        className={classes.label}
+      >
         {menuItem.label}
       </Typography>
     </Component>

--- a/src/SidebarDrawer/SidebarDrawer.tsx
+++ b/src/SidebarDrawer/SidebarDrawer.tsx
@@ -19,6 +19,8 @@ export type SideBarDrawerProps = BaseSidebarProps;
 export const SidebarDrawer: React.FC<SideBarDrawerProps> = ({
   menuItems,
   onMenuItemClick,
+  linkComponent,
+  logoHref,
 }) => {
   const [isOpened, setOpened] = React.useState(false);
   const classes = useStyles({});
@@ -42,6 +44,8 @@ export const SidebarDrawer: React.FC<SideBarDrawerProps> = ({
       top: 0,
     });
   };
+
+  const Link = linkComponent ?? "a";
 
   return (
     <>
@@ -67,9 +71,9 @@ export const SidebarDrawer: React.FC<SideBarDrawerProps> = ({
             })}
           >
             <div className={classes.content}>
-              <div className={classes.logo}>
+              <Link href={logoHref} className={classes.logo}>
                 {themeType === "dark" ? <LogoDark /> : <Logo />}
-              </div>
+              </Link>
               {menuItems.map((menuItem) => (
                 <MenuItemBtn
                   menuItem={menuItem}
@@ -78,6 +82,7 @@ export const SidebarDrawer: React.FC<SideBarDrawerProps> = ({
                       ? () => handleMenuItemWithChildrenClick(menuItem)
                       : handleMenuItemClick
                   }
+                  linkComponent={linkComponent}
                   key={menuItem.ariaLabel}
                 />
               ))}
@@ -104,6 +109,7 @@ export const SidebarDrawer: React.FC<SideBarDrawerProps> = ({
                         menuItem={subMenuItem}
                         onClick={handleMenuItemClick}
                         key={subMenuItem.ariaLabel}
+                        linkComponent={linkComponent}
                       />
                     );
                   }

--- a/src/utils/guideStyles.ts
+++ b/src/utils/guideStyles.ts
@@ -42,7 +42,7 @@ const useStyles = makeStyles(
       display: "grid",
       gridTemplateColumns: "repeat(3, 1fr)",
       gap: theme.spacing(3),
-    }
+    },
   }),
   { name: "Guide" }
 );


### PR DESCRIPTION
I want to merge this change in order to use custom Link component (for example from react-router) in Sidebar and SidebarDrawer so that we can open links from `Sidebar` and Logo inside `Sidebar` in new tab using Cmd+click