### PR TITLE
Fix ref errors and z index

### DIFF
--- a/src/Autocomplete/Autocomplete.tsx
+++ b/src/Autocomplete/Autocomplete.tsx
@@ -111,7 +111,7 @@ export const Autocomplete: React.FC<AutocompleteProps> = ({
       }
     },
   });
-  const menuProps = getMenuProps();
+  const menuProps = getMenuProps({}, { suppressRefError: true });
 
   React.useEffect(() => {
     if (
@@ -171,6 +171,7 @@ export const Autocomplete: React.FC<AutocompleteProps> = ({
               className={classes.dropdown}
               elevation={8}
               style={{ width: anchor.current?.clientWidth }}
+              {...menuProps}
               ref={mergeRefs(setAnchor, menuProps.ref)}
             >
               {children({

--- a/src/Autocomplete/Autocomplete.tsx
+++ b/src/Autocomplete/Autocomplete.tsx
@@ -1,4 +1,4 @@
-import { CircularProgress } from "@material-ui/core";
+import CircularProgress from "@material-ui/core/CircularProgress";
 import Grow from "@material-ui/core/Grow";
 import Paper from "@material-ui/core/Paper";
 import Popper, { PopperPlacementType } from "@material-ui/core/Popper";

--- a/src/Autocomplete/styles.ts
+++ b/src/Autocomplete/styles.ts
@@ -11,6 +11,8 @@ const useStyles = makeStyles(
     },
     popper: {
       marginTop: theme.spacing(1),
+      // Places popper above dialogs
+      zIndex: 1301,
     },
   }),
   { name: "Autocomplete" }

--- a/src/Autocomplete/styles.ts
+++ b/src/Autocomplete/styles.ts
@@ -1,3 +1,4 @@
+import { zIndex } from "../consts";
 import { makeStyles } from "../theme";
 
 const useStyles = makeStyles(
@@ -12,7 +13,7 @@ const useStyles = makeStyles(
     popper: {
       marginTop: theme.spacing(1),
       // Places popper above dialogs
-      zIndex: 1301,
+      zIndex: zIndex.popper,
     },
   }),
   { name: "Autocomplete" }

--- a/src/MultipleValueAutocomplete/styles.ts
+++ b/src/MultipleValueAutocomplete/styles.ts
@@ -31,6 +31,7 @@ const useStyles = makeStyles(
     },
     popper: {
       marginTop: theme.spacing(1),
+      zIndex: 1301,
     },
   }),
   { name: "MultipleValueAutocomplete" }

--- a/src/MultipleValueAutocomplete/styles.ts
+++ b/src/MultipleValueAutocomplete/styles.ts
@@ -1,3 +1,4 @@
+import { zIndex } from "../consts";
 import { makeStyles } from "../theme";
 
 const useStyles = makeStyles(
@@ -31,7 +32,7 @@ const useStyles = makeStyles(
     },
     popper: {
       marginTop: theme.spacing(1),
-      zIndex: 1301,
+      zIndex: zIndex.popper,
     },
   }),
   { name: "MultipleValueAutocomplete" }

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,1 +1,5 @@
 export const isWindowDefined = typeof window !== "undefined";
+export const zIndex = {
+  dialog: 1300,
+  popper: 1301,
+};


### PR DESCRIPTION
This PR fixes:
1. warning that ref is not properly mounted (it's a common problem with downshift and portals)
2. z-index in popper, because autocomplete components were unusable inside dialogs