### PR TITLE
Add support for router link and href in IconButton, fix Backlink

### DIFF
--- a/src/Autocomplete/Autocomplete.tsx
+++ b/src/Autocomplete/Autocomplete.tsx
@@ -1,4 +1,4 @@
-import { CircularProgress } from "@material-ui/core";
+import CircularProgress from "@material-ui/core/CircularProgress";
 import Grow from "@material-ui/core/Grow";
 import Paper from "@material-ui/core/Paper";
 import Popper, { PopperPlacementType } from "@material-ui/core/Popper";

--- a/src/IconButton/IconButton.tsx
+++ b/src/IconButton/IconButton.tsx
@@ -1,24 +1,40 @@
 import ButtonBase from "@material-ui/core/ButtonBase";
+import { IconButtonTypeMap as MuiIconButtonTypeMap } from "@material-ui/core/IconButton";
 import MuiIconButton, {
   IconButtonProps as MuiIconButtonProps,
 } from "@material-ui/core/IconButton";
+import { OverrideProps } from "@material-ui/core/OverridableComponent";
 import clsx from "clsx";
 import React from "react";
 
 import { UserInteraction } from "../../types/utils";
 import useStyles from "./styles";
 
-export type IconButtonProps<T extends React.ElementType = "button"> = Omit<
-  MuiIconButtonProps<T>,
-  "variant"
-> & {
+interface IconButtonInnerProps {
   error?: boolean;
   hoverOutline?: boolean;
   state?: UserInteraction;
   variant?: "primary" | "secondary";
-};
+}
 
-export const IconButton: React.FC<IconButtonProps> = React.forwardRef(
+export interface IconButtonTypeMap<
+  P = {},
+  D extends React.ElementType = "button"
+> {
+  props: Omit<MuiIconButtonTypeMap<P, D>["props"], "variant"> &
+    IconButtonInnerProps & { href?: string } & OverrideProps<
+      MuiIconButtonTypeMap<P, D>,
+      "a"
+    >;
+  defaultComponent: D;
+  classKey: never;
+}
+
+export type IconButtonProps<T extends React.ElementType = "button"> =
+  MuiIconButtonProps<T, { component?: T }> &
+    IconButtonInnerProps & { href?: string };
+
+const _IconButton: React.FC<IconButtonProps> = React.forwardRef(
   (
     {
       className,
@@ -64,4 +80,10 @@ export const IconButton: React.FC<IconButtonProps> = React.forwardRef(
     );
   }
 );
-IconButton.displayName = "Button";
+_IconButton.displayName = "Button";
+
+export const IconButton = _IconButton as <
+  T extends React.ElementType = "button"
+>(
+  props: IconButtonProps<T> & { ref?: React.ForwardedRef<T> }
+) => ReturnType<typeof _IconButton>;

--- a/src/LayoutButton/LayoutButton.tsx
+++ b/src/LayoutButton/LayoutButton.tsx
@@ -31,6 +31,7 @@ export const LayoutButtonInner = <T extends React.ElementType = "button">(
         [classes.hover]: state === "hover",
         [classes.active]: state === "active",
       })}
+      component={component}
       disableRipple
       ref={ref}
       {...rest}

--- a/src/SwitchSelector/SwitchSelector.stories.tsx
+++ b/src/SwitchSelector/SwitchSelector.stories.tsx
@@ -2,9 +2,9 @@ import { Typography } from "@material-ui/core";
 import { Meta, Story } from "@storybook/react";
 import React, { useState } from "react";
 
+import useGuideStyles from "../utils/guideStyles";
 import { SwitchSelector } from "./SwitchSelector";
 import { SwitchSelectorButton } from "./SwitchSelectorButton";
-import useGuideStyles from "../utils/guideStyles";
 
 type SwitchSelectorButtonOptions = {
   label: string | React.ReactNode;

--- a/src/SwitchSelector/SwitchSelector.tsx
+++ b/src/SwitchSelector/SwitchSelector.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+
 import { makeStyles } from "..";
 
 const useStyles = makeStyles((theme) => ({

--- a/src/SwitchSelector/SwitchSelectorButton.tsx
+++ b/src/SwitchSelector/SwitchSelectorButton.tsx
@@ -1,5 +1,6 @@
 import clsx from "clsx";
 import React from "react";
+
 import { Button, makeStyles } from "..";
 
 interface SwitchSelectorButtonProps {


### PR DESCRIPTION
I want to merge this because it adds support for polymorphic components in IconButton (ex. Link from react-router).
It also adds types for passing href prop to IconButton (supported by underlying IconButton and BaseButton from MUI) and fixes issues with Backlink not passing down component prop.
