### PR TITLE
Fix issues with Tooltip and Indicator

### DIFF
--- a/src/CircleIndicator/CircleIndicator.tsx
+++ b/src/CircleIndicator/CircleIndicator.tsx
@@ -11,6 +11,8 @@ export interface CircleIndicatorProps {
   color: CircleIndicatorColor;
 }
 
+/**
+ * @deprecated use IndicatorCircle component instead */
 export const CircleIndicator: React.FC<CircleIndicatorProps> = ({ color }) => {
   const { themeType } = useTheme();
   const classes = useStyles();

--- a/src/Indicator/index.ts
+++ b/src/Indicator/index.ts
@@ -1,1 +1,3 @@
 export * from "./Indicator";
+export * from "./IndicatorCircle";
+export * from "./IndicatorOutlined";

--- a/src/Indicator/styles.ts
+++ b/src/Indicator/styles.ts
@@ -28,36 +28,30 @@ export const useStyles = makeStyles<
   | "absolute"
   | "circlePath"
   | "circleOutline"
->((theme) => ({
-  wrapper: {
-    position: "relative",
-    display: "inline-block",
-    width: (props) => `${getSizeDimension(props.size)}px`,
-    height: (props) => `${getSizeDimension(props.size)}px`,
-    color: theme.palette.saleor.main[1],
-    //color: (props) => {
-    //if (props.variant === "outline") {
-    //return getBackgroundColor(theme)(props);
-    //}
-    //if (props.variant === "text") {
-    //return "inherit";
-    //}
-    //return theme.palette.saleor.main[1];
-    //},
-  },
-  wrapperCircle: {
-    color: getIconColor(theme, "mid"),
-  },
-  wrapperOutline: {
-    color: getIconColor(theme, "dark"),
-  },
-  absolute: {
-    position: "absolute",
-  },
-  circlePath: {
-    fill: getIconColor(theme, "mid"),
-  },
-  circleOutline: {
-    stroke: getIconColor(theme, "dark"),
-  },
-}));
+>(
+  (theme) => ({
+    wrapper: {
+      position: "relative",
+      display: "inline-block",
+      width: (props) => `${getSizeDimension(props.size)}px`,
+      height: (props) => `${getSizeDimension(props.size)}px`,
+      color: theme.palette.saleor.main[1],
+    },
+    wrapperCircle: {
+      color: getIconColor(theme, "mid"),
+    },
+    wrapperOutline: {
+      color: getIconColor(theme, "dark"),
+    },
+    absolute: {
+      position: "absolute",
+    },
+    circlePath: {
+      fill: getIconColor(theme, "mid"),
+    },
+    circleOutline: {
+      stroke: getIconColor(theme, "dark"),
+    },
+  }),
+  { name: "Indicator" }
+);

--- a/src/Indicator/styles.ts
+++ b/src/Indicator/styles.ts
@@ -45,6 +45,10 @@ export const useStyles = makeStyles<
     },
     absolute: {
       position: "absolute",
+      top: 0,
+      bottom: 0,
+      left: 0,
+      right: 0,
     },
     circlePath: {
       fill: getIconColor(theme, "mid"),

--- a/src/Tooltip/TooltipMountWrapper.tsx
+++ b/src/Tooltip/TooltipMountWrapper.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+
+import { useMountWrapperStyles } from "./styles";
+
+export interface MountWrapperProps
+  extends React.DetailedHTMLProps<
+    React.HTMLAttributes<HTMLButtonElement>,
+    HTMLButtonElement
+  > {
+  children: React.ReactNode;
+}
+
+/** Component used to wrap non-buttons for Tooltip support */
+export const TooltipMountWrapper = React.forwardRef<
+  HTMLButtonElement,
+  { children: React.ReactNode }
+>(({ children, ...props }, ref) => {
+  const classes = useMountWrapperStyles();
+
+  return (
+    <button className={classes.wrapper} {...props} ref={ref}>
+      {children}
+    </button>
+  );
+});

--- a/src/Tooltip/index.ts
+++ b/src/Tooltip/index.ts
@@ -1,1 +1,2 @@
 export * from "./Tooltip";
+export * from "./TooltipMountWrapper";

--- a/src/Tooltip/styles.ts
+++ b/src/Tooltip/styles.ts
@@ -138,3 +138,15 @@ export const useArrowStyles = makeStyles<StyleProps>(
   { name: "TooltipArrow" }
 );
 export default useStyles;
+
+export const useMountWrapperStyles = makeStyles(
+  {
+    wrapper: {
+      all: "unset",
+      display: "inline-block",
+      lineHeight: 0,
+      pointerEvents: "all",
+    },
+  },
+  { name: "TooltipMountWrapper" }
+);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -33,6 +33,7 @@ export * from "./List";
 export * from "./NavigationCard";
 export * from "./Pill";
 export * from "./CircleIndicator";
+export * from "./Indicator";
 export * from "./SwitchSelector";
 export * from "./Autocomplete";
 export * from "./MultipleValueAutocomplete";


### PR DESCRIPTION
I want to merge this because it fixes issues with new components:

**Indicator**
- Mark `CircleIndicator` as deprecated (superseded by `IndicatorCircle`)
- Add missing name in makeStyles to generate more readable classNames
- Add missing exports in `src/index.tsx` for Indicator folder
- Add missing exports in `/Indicator/index.ts` to export all Indicator components
- Fix absolute positioning of SVGs used inside flex container

**Tooltip**
- Add TooltipMountWrapper component for using Indicator without `<button>`