### PR TITLE
Add support for Link in Pagination

### DIFF
--- a/src/Pagination/Pagination.tsx
+++ b/src/Pagination/Pagination.tsx
@@ -8,8 +8,8 @@ import {
 } from "./PaginationRowNumberSelect";
 import useStyles from "./styles";
 
-export interface PaginationProps
-  extends PaginationActionsProps,
+export interface PaginationProps<ActionProps = {}>
+  extends PaginationActionsProps<ActionProps>,
     Omit<
       PaginationRowNumberSelectProps,
       "className" | "choices" | "onChange" | "rowNumber"
@@ -20,19 +20,20 @@ export interface PaginationProps
   onRowNumberUpdate?: (rowNumber: number) => void;
 }
 
-export const Pagination: React.FC<PaginationProps> = ({
+export const Pagination = <ActionProps,>({
   choices = [10, 20, 30, 50, 100],
   disabled,
   hasNextPage,
   hasPreviousPage,
   nextIconButtonProps,
+  prevIconButtonProps,
   labels,
   rowNumber,
   onNextPage,
   onPreviousPage,
   onRowNumberUpdate,
   ...other
-}) => {
+}: PaginationProps<ActionProps>): React.ReactElement => {
   const classes = useStyles();
 
   return (
@@ -53,6 +54,7 @@ export const Pagination: React.FC<PaginationProps> = ({
         hasNextPage={hasNextPage}
         hasPreviousPage={hasPreviousPage}
         nextIconButtonProps={nextIconButtonProps}
+        prevIconButtonProps={prevIconButtonProps}
         onNextPage={onNextPage}
         onPreviousPage={onPreviousPage}
       />

--- a/src/Pagination/PaginationActions.tsx
+++ b/src/Pagination/PaginationActions.tsx
@@ -18,8 +18,8 @@ export interface PaginationActionsProps<BProps = unknown> {
   hasPreviousPage: boolean;
   nextIconButtonProps?: BaseButtonProps<BProps>;
   prevIconButtonProps?: BaseButtonProps<BProps>;
-  onNextPage: () => void;
-  onPreviousPage: () => void;
+  onNextPage?: () => void;
+  onPreviousPage?: () => void;
 }
 
 export const PaginationActions = <BProps,>({
@@ -29,8 +29,8 @@ export const PaginationActions = <BProps,>({
   hasPreviousPage,
   nextIconButtonProps,
   prevIconButtonProps,
-  onNextPage,
-  onPreviousPage,
+  onNextPage = () => {},
+  onPreviousPage = () => {},
   ...other
 }: PaginationActionsProps<BProps>) => {
   const classes = useStyles();

--- a/src/Pagination/PaginationActions.tsx
+++ b/src/Pagination/PaginationActions.tsx
@@ -1,4 +1,4 @@
-import ButtonBase from "@material-ui/core/ButtonBase";
+import ButtonBase, { ButtonBaseTypeMap } from "@material-ui/core/ButtonBase";
 import ChevronLeft from "@material-ui/icons/ChevronLeft";
 import ChevronRight from "@material-ui/icons/ChevronRight";
 import clsx from "clsx";
@@ -7,26 +7,32 @@ import React from "react";
 import { useTheme } from "../theme";
 import useStyles from "./styles";
 
-export interface PaginationActionsProps {
+type BaseButtonProps<M = unknown> = M extends Object
+  ? ButtonBaseTypeMap<M & { component: React.ElementType }>["props"]
+  : ButtonBaseTypeMap<{ href?: string }>["props"];
+
+export interface PaginationActionsProps<BProps = unknown> {
   className?: string;
   disabled?: boolean;
   hasNextPage: boolean;
   hasPreviousPage: boolean;
-  nextIconButtonProps?: any;
+  nextIconButtonProps?: BaseButtonProps<BProps>;
+  prevIconButtonProps?: BaseButtonProps<BProps>;
   onNextPage: () => void;
   onPreviousPage: () => void;
 }
 
-export const PaginationActions: React.FC<PaginationActionsProps> = ({
+export const PaginationActions = <BProps,>({
   className,
   disabled,
   hasNextPage,
   hasPreviousPage,
   nextIconButtonProps,
+  prevIconButtonProps,
   onNextPage,
   onPreviousPage,
   ...other
-}) => {
+}: PaginationActionsProps<BProps>) => {
   const classes = useStyles();
 
   const { direction, themeType } = useTheme();
@@ -47,6 +53,7 @@ export const PaginationActions: React.FC<PaginationActionsProps> = ({
         disabled={previousDisabled}
         data-test="button-pagination-back"
         aria-label="previous page"
+        {...prevIconButtonProps}
       >
         {direction === "rtl" ? <ChevronRight /> : <ChevronLeft />}
       </ButtonBase>


### PR DESCRIPTION
I want to merge this because it adds support for custom Link component (ex. from react-router) into Pagination buttons. It also adds more strict TS types for type checking props passed into Pagination buttons
