### PR TITLE
Fix early return in Tooltip component

### DIFF
--- a/src/Tooltip/Tooltip.tsx
+++ b/src/Tooltip/Tooltip.tsx
@@ -110,10 +110,6 @@ export const Tooltip: React.FC<TooltipProps> = ({
 
   const classes = useStyles({ variant, side });
 
-  if (disabled) {
-    return children;
-  }
-
   const mountReference = React.useCallback(
     mergeRefs(reference, referenceRef),
     []
@@ -123,6 +119,10 @@ export const Tooltip: React.FC<TooltipProps> = ({
     arrowRef.current = el;
     update();
   }, []);
+
+  if (disabled) {
+    return children;
+  }
 
   return (
     <>


### PR DESCRIPTION
I want to merge this change because it moves early return clause behind hook calls in Tooltip component. This fixes inconsistent amount of hook calls when `disabled` prop changes.