### PR TITLE
Customize breakpoint in ResponsiveTable

### DIFF
--- a/src/ResponsiveTable/ResponsiveTable.tsx
+++ b/src/ResponsiveTable/ResponsiveTable.tsx
@@ -1,22 +1,32 @@
-import Table from "@material-ui/core/Table";
+import { Breakpoint } from "@material-ui/core/styles/createBreakpoints";
+import Table, { TableProps } from "@material-ui/core/Table";
 import React from "react";
 
 import useStyles from "./styles";
 
-interface ResponsiveTableProps {
+export interface ResponsiveTableProps
+  extends React.HTMLAttributes<HTMLDivElement> {
   children: React.ReactNode | React.ReactNodeArray;
+  flexBreakpoint?: Breakpoint;
+  tableProps?: TableProps;
   className?: string;
   key?: string;
 }
 
-export const ResponsiveTable: React.FC<ResponsiveTableProps> = (props) => {
-  const { children, className } = props;
-
-  const classes = useStyles(props);
+export const ResponsiveTable: React.FC<ResponsiveTableProps> = ({
+  children,
+  className,
+  tableProps,
+  flexBreakpoint,
+  ...props
+}) => {
+  const classes = useStyles({ flexBreakpoint });
 
   return (
-    <div className={classes.root}>
-      <Table className={className}>{children}</Table>
+    <div className={classes.root} {...props}>
+      <Table className={className} {...tableProps}>
+        {children}
+      </Table>
     </div>
   );
 };

--- a/src/ResponsiveTable/styles.ts
+++ b/src/ResponsiveTable/styles.ts
@@ -1,9 +1,10 @@
 import { makeStyles } from "../theme";
+import { ResponsiveTableProps } from "./ResponsiveTable";
 
-const useStyles = makeStyles(
+const useStyles = makeStyles<Pick<ResponsiveTableProps, "flexBreakpoint">>(
   (theme) => ({
-    root: {
-      [theme.breakpoints.up("md")]: {
+    root: (props) => ({
+      [theme.breakpoints.up(props.flexBreakpoint ?? "md")]: {
         "&& table": {
           tableLayout: "fixed",
         },
@@ -13,7 +14,7 @@ const useStyles = makeStyles(
       },
       overflowX: "auto",
       width: "100%",
-    },
+    }),
   }),
   {
     name: "ResponsiveTable",


### PR DESCRIPTION
I want to merge this, because it adds an option to customize breakpoint in ResponsiveTable. It also allows consumers of library to pass arbitrary props to `<Table>` and `<div>` components

Related dashboard PR: https://github.com/saleor/saleor-dashboard/pull/2234