### PR TITLE
Add colors to List.ItemGroup.Trigger

### DIFF
--- a/src/components/Icons/SVGWrapper/SVGWrapper.tsx
+++ b/src/components/Icons/SVGWrapper/SVGWrapper.tsx
@@ -8,8 +8,6 @@ export type SVGWrapperProps = SVGWrapperVariants & {
   viewBox?: string;
   children: ReactNode;
   color?: Sprinkles["color"];
-  backgroundColor?: Sprinkles["backgroundColor"];
-  borderRadius?: Sprinkles["borderRadius"];
 };
 
 export const SVGWrapper = forwardRef<SVGSVGElement, SVGWrapperProps>(
@@ -19,8 +17,6 @@ export const SVGWrapper = forwardRef<SVGSVGElement, SVGWrapperProps>(
       size,
       viewBox = "0 0 24 24",
       color = "iconNeutralDefault",
-      backgroundColor,
-      borderRadius,
       children,
     },
     ref
@@ -30,7 +26,7 @@ export const SVGWrapper = forwardRef<SVGSVGElement, SVGWrapperProps>(
         ref={ref}
         className={classNames(
           svgWrapper({ size }),
-          sprinkles({ color, backgroundColor, borderRadius }),
+          sprinkles({ color }),
           className
         )}
         viewBox={viewBox}

--- a/src/components/Icons/SVGWrapper/SVGWrapper.tsx
+++ b/src/components/Icons/SVGWrapper/SVGWrapper.tsx
@@ -8,6 +8,8 @@ export type SVGWrapperProps = SVGWrapperVariants & {
   viewBox?: string;
   children: ReactNode;
   color?: Sprinkles["color"];
+  backgroundColor?: Sprinkles["backgroundColor"];
+  borderRadius?: Sprinkles["borderRadius"];
 };
 
 export const SVGWrapper = forwardRef<SVGSVGElement, SVGWrapperProps>(
@@ -17,6 +19,8 @@ export const SVGWrapper = forwardRef<SVGSVGElement, SVGWrapperProps>(
       size,
       viewBox = "0 0 24 24",
       color = "iconNeutralDefault",
+      backgroundColor,
+      borderRadius,
       children,
     },
     ref
@@ -26,7 +30,7 @@ export const SVGWrapper = forwardRef<SVGSVGElement, SVGWrapperProps>(
         ref={ref}
         className={classNames(
           svgWrapper({ size }),
-          sprinkles({ color }),
+          sprinkles({ color, backgroundColor, borderRadius }),
           className
         )}
         viewBox={viewBox}

--- a/src/components/Icons/SVGWrapper/createSVGWrapper.tsx
+++ b/src/components/Icons/SVGWrapper/createSVGWrapper.tsx
@@ -6,5 +6,7 @@ export const createSVGWrapper = (node: ReactNode) => {
     <SVGWrapper {...props}>{node}</SVGWrapper>
   );
 
+  Wrapper.displayName = "withSVGWrapper";
+
   return Wrapper;
 };

--- a/src/components/Icons/icons.stories.tsx
+++ b/src/components/Icons/icons.stories.tsx
@@ -11,19 +11,23 @@ export default {
 
 export const Default = () =>
   sizes.map((size) => (
-    <>
-      <Text as="h3">{size}</Text>
+    <Box marginTop={5} key={size}>
+      <Text as="h3" variant="title">
+        {size}
+      </Text>
       <Box
         display="flex"
         alignItems="center"
         flexDirection="row"
         flexWrap="wrap"
+        gap={5}
       >
         {macawIcons.map((Icon, idx) => (
-          <Box margin={3} key={idx}>
+          <Box margin={3} key={idx} display="flex" flexDirection="column">
             <Icon size={size} />
+            <Text>{Icon.displayName}</Text>
           </Box>
         ))}
       </Box>
-    </>
+    </Box>
   ));

--- a/src/components/List/Item.tsx
+++ b/src/components/List/Item.tsx
@@ -11,10 +11,11 @@ type ListItemProps = Pick<
   disabled?: boolean;
   className?: string;
   onClick?: (event: React.MouseEvent<HTMLLIElement>) => void;
+  active?: boolean;
 };
 
 export const Item = forwardRef<HTMLLIElement, ListItemProps>(
-  ({ children, disabled, onClick, className, ...rest }, ref) => {
+  ({ children, disabled, onClick, className, active, ...rest }, ref) => {
     return (
       <Box
         {...rest}
@@ -24,7 +25,9 @@ export const Item = forwardRef<HTMLLIElement, ListItemProps>(
         cursor="pointer"
         disabled={disabled}
         backgroundColor={{
-          default: "interactiveNeutralDefault",
+          default: active
+            ? "interactiveNeutralHighlightFocused"
+            : "interactiveNeutralHighlightDefault",
           active: "interactiveNeutralHighlightPressing",
           hover: "interactiveNeutralHighlightHovering",
           focus: "interactiveNeutralHighlightFocused",

--- a/src/components/List/ItemGroup/Trigger.tsx
+++ b/src/components/List/ItemGroup/Trigger.tsx
@@ -19,7 +19,7 @@ export const Trigger = ({ children, ...rest }: ItemGroupTriggerProps) => (
   <AccordionTrigger asChild>
     <Item {...rest}>
       {children}
-      <ChervonDownIcon className={icon} />
+      <ChervonDownIcon className={icon} borderRadius={2} />
     </Item>
   </AccordionTrigger>
 );

--- a/src/components/List/ItemGroup/Trigger.tsx
+++ b/src/components/List/ItemGroup/Trigger.tsx
@@ -2,24 +2,35 @@ import { AccordionTrigger } from "@radix-ui/react-accordion";
 import { ReactNode } from "react";
 
 import { Sprinkles } from "~/theme";
-import { ChervonDownIcon } from "~/components";
+import { Box, ChervonDownIcon } from "~/components";
 
 import { Item } from "../Item";
 
-import { icon } from "./styles.css";
+import { button, icon } from "./styles.css";
 
 type ItemGroupTriggerProps = Pick<
   Sprinkles,
   "gap" | "paddingY" | "paddingX" | "borderRadius" | "justifyContent"
 > & {
   children: ReactNode;
+  active?: boolean;
 };
 
 export const Trigger = ({ children, ...rest }: ItemGroupTriggerProps) => (
   <AccordionTrigger asChild>
     <Item {...rest}>
       {children}
-      <ChervonDownIcon className={icon} borderRadius={2} />
+      {/* TODO: use Button component when it will be ready at */}
+      {/* https://github.com/saleor/saleor-dashboard/issues/3000 */}
+      <Box
+        as="button"
+        borderRadius={2}
+        backgroundColor="interactiveNeutralHighlightDefault"
+        className={button}
+        borderWidth={0}
+      >
+        <ChervonDownIcon className={icon} />
+      </Box>
     </Item>
   </AccordionTrigger>
 );

--- a/src/components/List/ItemGroup/styles.css.ts
+++ b/src/components/List/ItemGroup/styles.css.ts
@@ -1,4 +1,5 @@
 import { style } from "@vanilla-extract/css";
+import { vars } from "~/theme";
 
 export const trigger = style({});
 
@@ -7,6 +8,10 @@ export const icon = style({
   selectors: {
     [`${trigger}[data-state="open"] &`]: {
       transform: "rotate(180deg)",
+      // using vars here as sprinkles do not work currently in selectors
+      // https://github.com/vanilla-extract-css/vanilla-extract/discussions/824
+      backgroundColor:
+        vars.colors.background.interactiveNeutralHighlightFocused,
     },
   },
 });

--- a/src/components/List/ItemGroup/styles.css.ts
+++ b/src/components/List/ItemGroup/styles.css.ts
@@ -8,6 +8,13 @@ export const icon = style({
   selectors: {
     [`${trigger}[data-state="open"] &`]: {
       transform: "rotate(180deg)",
+    },
+  },
+});
+
+export const button = style({
+  selectors: {
+    [`${trigger}[data-state="open"] &`]: {
       // using vars here as sprinkles do not work currently in selectors
       // https://github.com/vanilla-extract-css/vanilla-extract/discussions/824
       backgroundColor:

--- a/src/components/List/List.stories.tsx
+++ b/src/components/List/List.stories.tsx
@@ -25,6 +25,15 @@ export const ItemDisabled = () => (
   </List>
 );
 
+export const ItemActive = () => (
+  <List>
+    <List.Item paddingX={4} paddingY={4} gap={5} borderRadius={3} active>
+      <HomeIcon color="iconNeutralSubdued" />
+      <Text>List component</Text>
+    </List.Item>
+  </List>
+);
+
 export const ListGroup = () => (
   <List>
     <List.ItemGroup>


### PR DESCRIPTION
## What was done

### Icons names in storybook
![CleanShot 2023-01-24 at 17 36 15@2x](https://user-images.githubusercontent.com/9116238/214352644-3fc84b38-bd98-4c15-b030-9f736bf0945f.jpg)
### Item active state
![CleanShot 2023-01-24 at 17 36 24@2x](https://user-images.githubusercontent.com/9116238/214352685-621efb09-b3cf-42fc-86a6-ed067cb32323.jpg)
### Background color for chevron when `List.ItemGroup.Trigger` is expanded
![CleanShot 2023-01-24 at 17 36 48@2x](https://user-images.githubusercontent.com/9116238/214352780-b95bd26e-faee-480f-bf5e-b41aed7df0ef.jpg)
