### PR TITLE
Fix deps 

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   "exports": {
     "./next": {
       "import": "./dist/macaw-ui.js",
-      "require": "./dist/macaw-ui.umd.cjs"
+      "require": "./dist/macaw-ui.umd.cjs",
+      "types": "./dist/index.d.ts"
     },
     "./next/style": {
       "import": "./dist/style.css",
@@ -35,7 +36,8 @@
     },
     ".": {
       "import": "./legacy/dist/esm/index.js",
-      "require": "./legacy/dist/cjs/index.js"
+      "require": "./legacy/dist/cjs/index.js",
+      "types": "./legacy/dist/types/index.d.ts"
     }
   },
   "keywords": [
@@ -117,6 +119,14 @@
     "@radix-ui/react-dropdown-menu": "^2.0.2",
     "@radix-ui/react-dialog": "^1.0.2",
     "@vanilla-extract/dynamic": "^2.0.3"
+  },
+  "dependencies": {
+    "@floating-ui/react-dom-interactions": "^0.5.0",
+    "clsx": "^1.1.1",
+    "downshift": "^6.1.7",
+    "lodash": "^4.17.21",
+    "lodash-es": "^4.17.21",
+    "react-inlinesvg": "^3.0.1"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3,6 +3,7 @@ lockfileVersion: 5.4
 specifiers:
   "@babel/core": ^7.20.7
   "@dessert-box/react": ^0.4.0
+  "@floating-ui/react-dom-interactions": ^0.5.0
   "@radix-ui/react-accordion": ^1.0.1
   "@radix-ui/react-dialog": ^1.0.2
   "@radix-ui/react-dropdown-menu": ^2.0.2
@@ -22,7 +23,9 @@ specifiers:
   "@vanilla-extract/sprinkles": ^1.5.1
   "@vanilla-extract/vite-plugin": ^3.7.0
   "@vitejs/plugin-react": ^2.2.0
+  clsx: ^1.1.1
   cross-env: ^7.0.3
+  downshift: ^6.1.7
   eslint: ^8.31.0
   eslint-config-prettier: ^8.6.0
   eslint-import-resolver-typescript: ^3.5.2
@@ -32,10 +35,13 @@ specifiers:
   husky: ^8.0.3
   is-ci: ^3.0.1
   lint-staged: ^13.1.0
+  lodash: ^4.17.21
+  lodash-es: ^4.17.21
   npm-run-all: ^4.1.5
   prettier: ^2.8.2
   react: ^17.0.2
   react-dom: ^17.0.2
+  react-inlinesvg: ^3.0.1
   release-it: ^15.6.0
   require-from-string: ^2.0.2
   typescript: ^4.9.3
@@ -43,6 +49,14 @@ specifiers:
   vite-plugin-dts: ^1.7.1
   vitest: ^0.27.2
   webpack: ^5.75.0
+
+dependencies:
+  "@floating-ui/react-dom-interactions": 0.5.0_gzv7pa6nrbev3fs6gyzn7sadkq
+  clsx: 1.2.1
+  downshift: 6.1.12_react@17.0.2
+  lodash: 4.17.21
+  lodash-es: 4.17.21
+  react-inlinesvg: 3.0.1_react@17.0.2
 
 devDependencies:
   "@babel/core": 7.20.12
@@ -1882,7 +1896,6 @@ packages:
     engines: { node: ">=6.9.0" }
     dependencies:
       regenerator-runtime: 0.13.11
-    dev: true
 
   /@babel/runtime/7.5.5:
     resolution:
@@ -1995,7 +2008,7 @@ packages:
     dependencies:
       "@babel/runtime": 7.20.7
       "@types/react": 17.0.52
-      clsx: 1.1.0
+      clsx: 1.2.1
       focus-lock: 0.8.1
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -2147,7 +2160,6 @@ packages:
       {
         integrity: sha512-buc8BXHmG9l82+OQXOFU3Kr2XQx9ys01U/Q9HMIrZ300iLc8HLMgh7dcCqgYzAzf4BkoQvDcXf5Y+CuEZ5JBYg==,
       }
-    dev: true
 
   /@floating-ui/dom/0.5.4:
     resolution:
@@ -2156,7 +2168,22 @@ packages:
       }
     dependencies:
       "@floating-ui/core": 0.7.3
-    dev: true
+
+  /@floating-ui/react-dom-interactions/0.5.0_gzv7pa6nrbev3fs6gyzn7sadkq:
+    resolution:
+      {
+        integrity: sha512-rfON7mkHjCeogd0BSXPa8GBp1TMxEytJQqGVlCouSUonJ4POqdHsqcxRnCh0yAaGVaL/nB/J1vq28V4RdoLszg==,
+      }
+    deprecated: Package renamed to @floating-ui/react
+    dependencies:
+      "@floating-ui/react-dom": 0.7.2_gzv7pa6nrbev3fs6gyzn7sadkq
+      aria-hidden: 1.2.2_q5o373oqrklnndq2vhekyuzhxi
+      use-isomorphic-layout-effect: 1.1.2_q5o373oqrklnndq2vhekyuzhxi
+    transitivePeerDependencies:
+      - "@types/react"
+      - react
+      - react-dom
+    dev: false
 
   /@floating-ui/react-dom/0.7.2_gzv7pa6nrbev3fs6gyzn7sadkq:
     resolution:
@@ -2173,7 +2200,6 @@ packages:
       use-isomorphic-layout-effect: 1.1.2_q5o373oqrklnndq2vhekyuzhxi
     transitivePeerDependencies:
       - "@types/react"
-    dev: true
 
   /@gar/promisify/1.1.3:
     resolution:
@@ -5092,7 +5118,6 @@ packages:
       {
         integrity: sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==,
       }
-    dev: true
 
   /@types/qs/6.9.7:
     resolution:
@@ -5119,14 +5144,12 @@ packages:
       "@types/prop-types": 15.7.5
       "@types/scheduler": 0.16.2
       csstype: 3.1.1
-    dev: true
 
   /@types/scheduler/0.16.2:
     resolution:
       {
         integrity: sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==,
       }
-    dev: true
 
   /@types/semver/7.3.13:
     resolution:
@@ -6236,7 +6259,6 @@ packages:
       "@types/react": 17.0.52
       react: 17.0.2
       tslib: 2.4.1
-    dev: true
 
   /arr-diff/4.0.0:
     resolution:
@@ -7684,6 +7706,13 @@ packages:
     engines: { node: ">=6" }
     dev: true
 
+  /clsx/1.2.1:
+    resolution:
+      {
+        integrity: sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==,
+      }
+    engines: { node: ">=6" }
+
   /code-block-writer/11.0.3:
     resolution:
       {
@@ -7862,6 +7891,13 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
+
+  /compute-scroll-into-view/1.0.20:
+    resolution:
+      {
+        integrity: sha512-UCB0ioiyj8CRjtrvaceBLqqhZCVP+1B8+NWQhmdsm0VXOJtobBCf1dBQmebCCo34qZmUwZfIH2MZLqNHazrfjg==,
+      }
+    dev: false
 
   /concat-map/0.0.1:
     resolution:
@@ -8267,7 +8303,6 @@ packages:
       {
         integrity: sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==,
       }
-    dev: true
 
   /currently-unhandled/0.4.1:
     resolution:
@@ -8760,6 +8795,22 @@ packages:
       }
     engines: { node: ">=10" }
     dev: true
+
+  /downshift/6.1.12_react@17.0.2:
+    resolution:
+      {
+        integrity: sha512-7XB/iaSJVS4T8wGFT3WRXmSF1UlBHAA40DshZtkrIscIN+VC+Lh363skLxFTvJwtNgHxAMDGEHT4xsyQFWL+UA==,
+      }
+    peerDependencies:
+      react: ">=16.12.0"
+    dependencies:
+      "@babel/runtime": 7.20.7
+      compute-scroll-into-view: 1.0.20
+      prop-types: 15.8.1
+      react: 17.0.2
+      react-is: 17.0.2
+      tslib: 2.4.1
+    dev: false
 
   /duplexify/3.7.1:
     resolution:
@@ -9928,6 +9979,13 @@ packages:
       signal-exit: 3.0.7
       strip-final-newline: 3.0.0
     dev: true
+
+  /exenv/1.2.2:
+    resolution:
+      {
+        integrity: sha512-Z+ktTxTwv9ILfgKCk32OX3n/doe+OcLTRtqK9pcL+JsP3J1/VW8Uvl4ZjLlKqeW4rzK4oesDOGMEMRIZqtP4Iw==,
+      }
+    dev: false
 
   /expand-brackets/2.1.4:
     resolution:
@@ -12667,7 +12725,6 @@ packages:
       {
         integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==,
       }
-    dev: true
 
   /js-yaml/3.14.1:
     resolution:
@@ -13091,6 +13148,13 @@ packages:
       p-locate: 5.0.0
     dev: true
 
+  /lodash-es/4.17.21:
+    resolution:
+      {
+        integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==,
+      }
+    dev: false
+
   /lodash.debounce/4.0.8:
     resolution:
       {
@@ -13131,7 +13195,6 @@ packages:
       {
         integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==,
       }
-    dev: true
 
   /log-symbols/5.1.0:
     resolution:
@@ -13165,7 +13228,6 @@ packages:
     hasBin: true
     dependencies:
       js-tokens: 4.0.0
-    dev: true
 
   /loud-rejection/1.6.0:
     resolution:
@@ -14165,7 +14227,6 @@ packages:
         integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==,
       }
     engines: { node: ">=0.10.0" }
-    dev: true
 
   /object-copy/0.1.0:
     resolution:
@@ -15396,7 +15457,6 @@ packages:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
-    dev: true
 
   /property-information/5.6.0:
     resolution:
@@ -15725,7 +15785,6 @@ packages:
       object-assign: 4.1.1
       react: 17.0.2
       scheduler: 0.20.2
-    dev: true
 
   /react-element-to-jsx-string/14.3.4_sfoxds7t5ydpegc3knd667wn6m:
     resolution:
@@ -15742,6 +15801,30 @@ packages:
       react-dom: 17.0.2_react@17.0.2
       react-is: 17.0.2
     dev: true
+
+  /react-from-dom/0.6.2_react@17.0.2:
+    resolution:
+      {
+        integrity: sha512-qvWWTL/4xw4k/Dywd41RBpLQUSq97csuv15qrxN+izNeLYlD9wn5W8LspbfYe5CWbaSdkZ72BsaYBPQf2x4VbQ==,
+      }
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      react: 17.0.2
+    dev: false
+
+  /react-inlinesvg/3.0.1_react@17.0.2:
+    resolution:
+      {
+        integrity: sha512-cBfoyfseNI2PkDA7ZKIlDoHq0eMfpoC3DhKBQNC+/X1M4ZQB+aXW+YiNPUDDDKXUsGDUIZWWiZWNFeauDIVdoA==,
+      }
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      exenv: 1.2.2
+      react: 17.0.2
+      react-from-dom: 0.6.2_react@17.0.2
+    dev: false
 
   /react-inspector/5.1.1_react@17.0.2:
     resolution:
@@ -15762,14 +15845,12 @@ packages:
       {
         integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==,
       }
-    dev: true
 
   /react-is/17.0.2:
     resolution:
       {
         integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==,
       }
-    dev: true
 
   /react-merge-refs/1.1.0:
     resolution:
@@ -15864,7 +15945,6 @@ packages:
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
-    dev: true
 
   /read-pkg-up/1.0.1:
     resolution:
@@ -16036,7 +16116,6 @@ packages:
       {
         integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==,
       }
-    dev: true
 
   /regenerator-transform/0.15.1:
     resolution:
@@ -16628,7 +16707,6 @@ packages:
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
-    dev: true
 
   /schema-utils/1.0.0:
     resolution:
@@ -18070,7 +18148,6 @@ packages:
       {
         integrity: sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==,
       }
-    dev: true
 
   /tsutils/3.21.0_typescript@4.9.4:
     resolution:
@@ -18632,7 +18709,6 @@ packages:
     dependencies:
       "@types/react": 17.0.52
       react: 17.0.2
-    dev: true
 
   /use-sidecar/1.1.2_q5o373oqrklnndq2vhekyuzhxi:
     resolution:


### PR DESCRIPTION
### What was done?
* Add dependencies from `legacy` to the main package? Why? It allows users to use both `@saleor/macaw` i `@saleor/macaw-ui/next` without installing additional dependencies. If not this change they will need to install all those deps by themselves. It is a problem as previous versions do not need those deps to work (they bundle them)
* Add `types` for better IDE typing support (other than VSCode)