### PR TITLE
Pass proper chevron icon size

### DIFF
--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -107,7 +107,7 @@ const TextIconButtonVariants = (props: Omit<ButtonProps, "children">) => (
         Button
       </Button>
       <Button variant="primary" size="small" {...props}>
-        <SearchIcon size="xsmall" />
+        <SearchIcon size="small" />
         Button
       </Button>
     </ButtonSetWrapper>
@@ -121,7 +121,7 @@ const TextIconButtonVariants = (props: Omit<ButtonProps, "children">) => (
         Button
       </Button>
       <Button variant="secondary" size="small" {...props}>
-        <SearchIcon size="xsmall" />
+        <SearchIcon size="small" />
         Button
       </Button>
     </ButtonSetWrapper>
@@ -135,14 +135,14 @@ const TextIconButtonVariants = (props: Omit<ButtonProps, "children">) => (
         Button
       </Button>
       <Button variant="tertiary" size="small" {...props}>
-        <SearchIcon size="xsmall" />
+        <SearchIcon size="small" />
         Button
       </Button>
     </ButtonSetWrapper>
   </>
 );
 
-export const Template: ComponentStory<typeof Button> = () => (
+export const Default: ComponentStory<typeof Button> = () => (
   <>
     <Box display="flex" flexDirection="row" marginBottom={11} paddingTop={11}>
       <TextButtonVariants />

--- a/src/components/Icons/SVGWrapper/SVGWrapper.css.ts
+++ b/src/components/Icons/SVGWrapper/SVGWrapper.css.ts
@@ -5,13 +5,9 @@ import { vars } from "~/theme";
 export const svgWrapper = recipe({
   variants: {
     size: {
-      xsmall: {
+      small: {
         width: vars.space[7],
         height: vars.space[7],
-      },
-      small: {
-        width: vars.space[8],
-        height: vars.space[8],
       },
       medium: {
         width: vars.space[9],

--- a/src/components/Icons/icons.stories.tsx
+++ b/src/components/Icons/icons.stories.tsx
@@ -3,7 +3,7 @@ import { Box } from "~/components/Box";
 import * as icons from "./index";
 
 const macawIcons = Object.values(icons);
-const sizes = ["xsmall", "small", "medium", "large"] as const;
+const sizes = ["small", "medium", "large"] as const;
 
 export default {
   title: "components/Icons",

--- a/src/components/List/ItemGroup/Trigger.tsx
+++ b/src/components/List/ItemGroup/Trigger.tsx
@@ -23,7 +23,13 @@ export const Trigger = ({ children, size, ...rest }: ItemGroupTriggerProps) => (
     <List.Item {...rest}>
       {children}
       <Button
-        icon={<ChervonDownIcon className={icon} color="iconNeutralDefault" />}
+        icon={
+          <ChervonDownIcon
+            className={icon}
+            color="iconNeutralDefault"
+            size={size}
+          />
+        }
         variant="tertiary"
         size={size}
         className={button}


### PR DESCRIPTION
### What was done?
* I've removed an `xsmall` variant from the icon as small icon currently is 16x16
* Added ability to pass size to `ListItemGroup.Trigger`