### PR TITLE
Add display: contents to sprinkles

### DIFF
--- a/src/theme/sprinkles.css.ts
+++ b/src/theme/sprinkles.css.ts
@@ -9,7 +9,7 @@ const responsiveProperties = defineProperties({
   },
   defaultCondition: "mobile",
   properties: {
-    display: ["none", "flex", "grid", "block"],
+    display: ["none", "flex", "grid", "block", "contents"],
     flexDirection: ["row", "column"],
     alignItems: ["stretch", "flex-start", "center", "flex-end"],
     justifyContent: [


### PR DESCRIPTION
We have following use case in the dashboard: `<a>` tags are used as wrappers which allow right clicking and/or opening stuff in new tabs. Using `display: contents` on them makes them not interfere with flexbox styling or child selectors.