### PR TITLE
Add ellipsis to Text

### DIFF
--- a/src/components/Text/Text.css.ts
+++ b/src/components/Text/Text.css.ts
@@ -213,6 +213,7 @@ export const text = recipe({
   defaultVariants: {
     variant: "body",
     size: "medium",
+    ellipsis: false,
   },
 });
 

--- a/src/components/Text/Text.css.ts
+++ b/src/components/Text/Text.css.ts
@@ -21,6 +21,15 @@ export const text = recipe({
       medium: {},
       large: {},
     },
+    ellipsis: {
+      multiline: sprinkles({ overflow: "hidden", textOverflow: "ellipsis" }),
+      true: sprinkles({
+        overflow: "hidden",
+        textOverflow: "ellipsis",
+        whiteSpace: "nowrap",
+      }),
+      false: {},
+    },
   },
 
   compoundVariants: [

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -21,6 +21,7 @@ export const Text = forwardRef<HTMLSpanElement, TextProps>(
       as = "span",
       variant,
       size,
+      ellipsis,
       color = "textNeutralDefault",
       className,
       ...rest
@@ -30,7 +31,7 @@ export const Text = forwardRef<HTMLSpanElement, TextProps>(
     return (
       <Box
         as={as}
-        className={classNames(text({ variant, size }), className)}
+        className={classNames(text({ variant, size, ellipsis }), className)}
         color={color}
         ref={ref}
         margin={0}

--- a/src/theme/sprinkles.css.ts
+++ b/src/theme/sprinkles.css.ts
@@ -129,6 +129,8 @@ const responsiveProperties = defineProperties({
     right: vars.space,
     overflowX: ["hidden", "visible", "scroll", "auto"],
     overflowY: ["hidden", "visible", "scroll", "auto"],
+    textOverflow: ["none", "ellipsis"],
+    whiteSpace: ["normal", "nowrap"],
     zIndex: ["auto", "1", "2", "3"],
   },
   shorthands: {


### PR DESCRIPTION
This PR adds `ellipsis` parameter to Text component in 3 variants:
- `true` with `whitespace: nowrap`, for single-line overflowing spans (working in containers with set width)
- `multiline` without nowrap, for multi-line overflowing spans (working in containers with set width & height)
- `false` which is default and current behaviour.