### PR TITLE
Add aspect ratio & object-fit to sprinkles

### DIFF
--- a/src/theme/sprinkles.css.ts
+++ b/src/theme/sprinkles.css.ts
@@ -144,6 +144,8 @@ const responsiveProperties = defineProperties({
     textOverflow: ["none", "ellipsis"],
     whiteSpace: ["normal", "nowrap"],
     zIndex: ["auto", "1", "2", "3"],
+    aspectRatio: ["1 / 1"],
+    objectFit: ["contain", "cover", "fill", "none", "scale-down"],
   },
   shorthands: {
     padding: ["paddingTop", "paddingBottom", "paddingLeft", "paddingRight"],


### PR DESCRIPTION
This PR adds css properties useful for resizing thumbnails, e.g: 
Before:
<img width="378" alt="image" src="https://user-images.githubusercontent.com/41952692/223420487-fbf11c8d-4bbb-4d19-bd32-11cde7d5eec8.png">
After:

<img width="375" alt="image" src="https://user-images.githubusercontent.com/41952692/223420627-6b037672-7091-4f77-a0d3-cf0bc76a4ccd.png">
