### PR TITLE
Add fill size variant to icon components

### DIFF
--- a/src/components/Icons/SVGWrapper/SVGWrapper.css.ts
+++ b/src/components/Icons/SVGWrapper/SVGWrapper.css.ts
@@ -17,6 +17,7 @@ export const svgWrapper = recipe({
         width: vars.space[9],
         height: vars.space[9],
       },
+      fill: {},
     },
   },
   defaultVariants: {


### PR DESCRIPTION
This PR adds `fill` variant for icon size which allows for variable-sized icons.
<img width="738" alt="image" src="https://user-images.githubusercontent.com/41952692/223440009-d344558c-552b-46e7-a6df-0421f4b85e4e.png">
