### PR TITLE
Add opacity to sprinkles

### DIFF
--- a/src/theme/sprinkles.css.ts
+++ b/src/theme/sprinkles.css.ts
@@ -147,6 +147,7 @@ const responsiveProperties = defineProperties({
     zIndex: ["auto", "1", "2", "3"],
     aspectRatio: ["1 / 1"],
     objectFit: ["contain", "cover", "fill", "none", "scale-down"],
+    opacity: ["0", "0.2", "0.4", "0.6", "0.8", "1"],
     fontWeight: vars.fontWeight,
   },
   shorthands: {


### PR DESCRIPTION
This PR adds `opacity` css property to sprinkles with the following values: `0` | `0.2` | `0.4` | `0.6` | `0.8` | `1`