### PR TITLE
Fix `PropsWithBox` types

### DIFF
--- a/src/components/Box/Box.tsx
+++ b/src/components/Box/Box.tsx
@@ -5,4 +5,4 @@ import { sprinkles } from "~/theme";
 
 export const Box = createBox({ atoms: sprinkles });
 
-export type PropsWithBox<T> = ComponentProps<typeof Box> & T;
+export type PropsWithBox<T> = Omit<ComponentProps<typeof Box>, keyof T> & T;

--- a/src/components/List/ItemGroup/Trigger.tsx
+++ b/src/components/List/ItemGroup/Trigger.tsx
@@ -13,9 +13,8 @@ export type ItemGroupTriggerProps = PropsWithBox<
   DataAttributes & {
     children: ReactNode;
     active?: boolean;
-    [key: `data-${string}`]: string;
-    size?: "small" | "medium" | "large";
     url?: string;
+    size?: "small" | "medium" | "large";
   }
 >;
 

--- a/src/components/List/List.stories.tsx
+++ b/src/components/List/List.stories.tsx
@@ -46,6 +46,7 @@ export const ListGroup = () => (
         borderRadius={3}
         justifyContent="space-between"
         gap={6}
+        size="medium"
       >
         <Box display="flex" alignItems="center" gap={6}>
           <MenuIcon color="iconNeutralDefault" />


### PR DESCRIPTION
It fixes `PropsWithBox` types so properties passed into the `PropsWithBox` generic will override those from `Box`. 

Take `ItemGroupTriggerProps` where the `size` property is coming from both custom code `size?: "small" | "medium" | "large"` and from `Box` where `size: number | undefined`. Before the fix size was resolved as `number` and after the fix is resolved as `"small" | "medium" | "large"`.