### PR TITLE
Set position relative to label

### DIFF
--- a/src/components/Checkbox/Checkbox.css.ts
+++ b/src/components/Checkbox/Checkbox.css.ts
@@ -14,7 +14,6 @@ export const commonCheckbox = sprinkles({
   borderRadius: 1,
   borderWidth: 1,
   color: "iconNeutralContrasted",
-  position: "relative",
 });
 
 export const defaultCheckbox = style({

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -25,7 +25,13 @@ export const Checkbox = forwardRef<HTMLButtonElement, CheckboxProps>(
     const iconColor = disabled ? "iconNeutralSubdued" : "iconNeutralContrasted";
 
     return (
-      <Box as="label" display="flex" alignItems="center" gap={4}>
+      <Box
+        as="label"
+        display="flex"
+        alignItems="center"
+        gap={4}
+        position="relative"
+      >
         <RadixCheckbox
           ref={ref}
           className={classNames(

--- a/src/components/RadioGroup/Item.tsx
+++ b/src/components/RadioGroup/Item.tsx
@@ -22,6 +22,7 @@ export const RadioGroupItem = forwardRef<HTMLDivElement, RadioGroupItemProps>(
       display="flex"
       alignItems="center"
       gap={4}
+      position="relative"
       {...rest}
       className={className}
       ref={ref}


### PR DESCRIPTION
If you put the checkbox or radio inside the form it becomes an `input` component and the previous position relative does not work. After this fix, I apply `position:relative` to the label.