### PR TITLE
Fix input and add additional props to sprinkles

### DIFF
--- a/src/components/Input/Input.css.ts
+++ b/src/components/Input/Input.css.ts
@@ -1,6 +1,6 @@
 import { style } from "@vanilla-extract/css";
 import { recipe, RecipeVariants } from "@vanilla-extract/recipes";
-import { sprinkles } from "~/theme";
+import { sprinkles, vars } from "~/theme";
 
 export const label = recipe({
   base: [
@@ -195,6 +195,22 @@ export const input = recipe({
         disabled: "textNeutralSubdued",
       },
     }),
+    {
+      selectors: {
+        "&::-webkit-input-placeholder": {
+          color: "transparent",
+        },
+        "&::-moz-placeholder": {
+          color: "transparent",
+        },
+        "&:focus::-webkit-input-placeholder": {
+          color: vars.colors.foreground.textNeutralSubdued,
+        },
+        "&:focus::-moz-placeholder": {
+          color: vars.colors.foreground.textNeutralSubdued,
+        },
+      },
+    },
   ],
   variants: {
     size: {

--- a/src/components/Input/Input.stories.tsx
+++ b/src/components/Input/Input.stories.tsx
@@ -9,7 +9,13 @@ export default {
 export const Default: ComponentStory<typeof Input> = () => (
   <Box display="flex" flexDirection="column">
     <Box paddingY={9} display="flex" gap={9} alignItems="center">
-      <Input id="inp11" value="Input content" label="Label" size="large" />
+      <Input
+        id="inp11"
+        value="Input content"
+        label="Label"
+        size="large"
+        placeholder="Input placeholder"
+      />
       <Input id="inp12" value="Input content" label="Label" size="medium" />
       <Input id="inp13" value="Input content" label="Label" size="small" />
     </Box>
@@ -21,6 +27,7 @@ export const Default: ComponentStory<typeof Input> = () => (
         size="large"
         error
       />
+
       <Input
         id="inp12e"
         value="Input content error"
@@ -72,6 +79,31 @@ export const Default: ComponentStory<typeof Input> = () => (
         label="Label"
         size="small"
         disabled
+      />
+    </Box>
+    <Box paddingY={9} display="flex" gap={9} alignItems="center">
+      <Input
+        id="inp413"
+        value="Input content"
+        label="Label"
+        size="large"
+        helperText="Default helper text"
+      />
+      <Input
+        id="inp423"
+        value="Input content"
+        label="Label"
+        size="medium"
+        error
+        helperText="Error helper text"
+      />
+      <Input
+        id="inp433"
+        value="Input content"
+        label="Label"
+        size="small"
+        disabled
+        helperText="Disabled helper text"
       />
     </Box>
   </Box>

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -1,19 +1,26 @@
-import { forwardRef, InputHTMLAttributes } from "react";
+import { forwardRef, InputHTMLAttributes, ReactNode } from "react";
+
 import { classNames } from "~/utils";
+
 import { InputWrapper, useStateEvents } from "./InputWrapper";
 import { Box } from "../Box";
+import { Text } from "../Text";
 import { input as inputStyle, InputVariants } from "./Input.css";
 
 export type InputProps = InputVariants &
   Omit<
     InputHTMLAttributes<HTMLInputElement>,
-    "color" | "width" | "height" | "size"
-  > & { label?: string; error?: boolean };
+    "color" | "width" | "height" | "size" | "type" | "children"
+  > & {
+    label?: ReactNode;
+    error?: boolean;
+    type?: "text" | "number";
+    helperText?: ReactNode;
+  };
 
 export const Input = forwardRef<HTMLInputElement, InputProps>(
   (
     {
-      children,
       size,
       disabled = false,
       className,
@@ -23,6 +30,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
       type,
       error = false,
       onChange,
+      helperText,
       ...props
     },
     ref
@@ -35,29 +43,41 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
     } = useStateEvents(value, onChange);
 
     return (
-      <InputWrapper
-        id={id}
-        typed={typed}
-        active={active}
-        disabled={disabled}
-        size={size}
-        label={label}
-        error={error}
-        className={className}
-      >
-        <Box
+      <Box display="flex" flexDirection="column">
+        <InputWrapper
           id={id}
-          as="input"
-          type={type}
-          className={classNames(inputStyle({ size, error }))}
+          typed={typed}
+          active={active}
           disabled={disabled}
-          value={inputValue}
-          ref={ref}
-          {...handlers}
-          {...props}
-        />
-        {children}
-      </InputWrapper>
+          size={size}
+          label={label}
+          error={error}
+          className={className}
+        >
+          <Box
+            id={id}
+            as="input"
+            type={type}
+            className={classNames(inputStyle({ size, error }))}
+            disabled={disabled}
+            value={inputValue}
+            ref={ref}
+            {...handlers}
+            {...props}
+          />
+        </InputWrapper>
+        {helperText && (
+          <Box paddingLeft={4}>
+            <Text
+              variant="caption"
+              size={size}
+              color={error ? "textCriticalDefault" : "textNeutralSubdued"}
+            >
+              {helperText}
+            </Text>
+          </Box>
+        )}
+      </Box>
     );
   }
 );

--- a/src/components/Input/InputWrapper.tsx
+++ b/src/components/Input/InputWrapper.tsx
@@ -46,7 +46,7 @@ export const useStateEvents = (
 
 type InputWrapperProps = LabelVariants & {
   id?: string;
-  label?: string;
+  label?: ReactNode;
   className?: string;
   error?: boolean;
   children: ReactNode;

--- a/src/theme/sprinkles.css.ts
+++ b/src/theme/sprinkles.css.ts
@@ -149,6 +149,7 @@ const responsiveProperties = defineProperties({
     objectFit: ["contain", "cover", "fill", "none", "scale-down"],
     opacity: ["0", "0.2", "0.4", "0.6", "0.8", "1"],
     fontWeight: vars.fontWeight,
+    alignSelf: ["auto", "normal", "end", "center", "start"],
   },
   shorthands: {
     padding: ["paddingTop", "paddingBottom", "paddingLeft", "paddingRight"],


### PR DESCRIPTION
### What was done?
#### Added support for placeholder
![CleanShot 2023-03-24 at 15 11 32@2x](https://user-images.githubusercontent.com/9116238/227545134-5e420af7-2c98-4a70-9081-b6b38079809e.jpg)
![CleanShot 2023-03-24 at 15 11 38@2x](https://user-images.githubusercontent.com/9116238/227545179-9683d4fc-b230-4e90-828e-ae50965a5adf.jpg)
#### Enabled only `text & `number` input types
Other input [types](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#input_types) are currently not supported and lead to broken UI
#### Added `helperText` prop to render error message or field description under input
<img width="734" alt="image" src="https://user-images.githubusercontent.com/9116238/227546083-f7e20dd0-71e0-4ced-a3a4-892297beeb56.png">

#### Various

* Changed `label` and `helperText` to `ReactNode` as we have cases in the dashboard where we would like to render some JSX instead of pure text
* Added `alignSelf` to sprinkles