### PR TITLE
Fix: input TypeScript types

### DIFF
--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -10,7 +10,7 @@ import { input as inputStyle, InputVariants } from "./Input.css";
 export type InputProps = PropsWithBox<
   Omit<
     InputHTMLAttributes<HTMLInputElement>,
-    "color" | "width" | "height" | "size" | "type" | "children"
+    "color" | "width" | "height" | "size" | "type" | "children" | "nonce"
   > & {
     label?: ReactNode;
     error?: boolean;


### PR DESCRIPTION
It fixes TypeScript errors in dashboard:

```
src/products/components/ProductStocks/ProductStocks.tsx:473:22 - error TS2741: Property 'nonce' is missing in type '{ min: number; type: "number"; name: string; disabled: boolean; onChange: (e: ChangeEvent<HTMLInputElement>) => void; value: string | number; size: "small"; placeholder: string; }' but required in type 'Pick<Omit<{ as?: ElementType<any>; children?: ReactNode; className?: string; style?: Record<string, any>; } & { display?: "flex" | "grid" | "none" | "contents" | "block" | { ...; }; ... 86 more ...; flex?: "0" | { ...; }; } & { ...; } & { ...; } & { ...; } & RefAttributes<...>, "translate" | ... 284 more ... | "ente...'.

473                     <Input
                         ~~~~~
```