### PR TITLE
fix: apply background color plain to HTML body

### DIFF
--- a/.storybook/preview.jsx
+++ b/.storybook/preview.jsx
@@ -31,13 +31,7 @@ const ThemeSwitcher = ({ children, context }) => {
   }, [context.globals.theme]);
 
   return (
-    <Box
-      backgroundColor="plain"
-      width="100vw"
-      height="100vh"
-      display="flex"
-      justifyContent="center"
-    >
+    <Box width="100vw" height="100vh" display="flex" justifyContent="center">
       {children}
     </Box>
   );

--- a/src/theme/global.css.ts
+++ b/src/theme/global.css.ts
@@ -1,0 +1,6 @@
+import { globalStyle } from "@vanilla-extract/css";
+import { vars } from "./contract.css";
+
+globalStyle("body", {
+  backgroundColor: vars.colors.background.plain,
+});

--- a/src/theme/provider.tsx
+++ b/src/theme/provider.tsx
@@ -1,5 +1,6 @@
 import "./reset.css";
 import "./fonts.css";
+import "./global.css";
 
 import { ThemeContextProvider } from "./context";
 import { DefaultTheme } from "./themes";


### PR DESCRIPTION
This PR applies `colors.background.plain` to body when you are using `ThemeProvider`