### PR TITLE
build: run CI only on PR

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,5 @@
 name: CI
-on: [push]
+on: [pull_request]
 jobs:
   build:
     name: Lint, check types and test


### PR DESCRIPTION
I want to merge this change because it changes how `Lint, check types, and test` is run - from now on it will be only executed on pull requests. Previously it was run on push to every branch e.g main.



### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

- [x] New components are exported from `./src/components/index.ts`.
- [x] Storybook story is created and documentation properly generated.
