### PR TITLE
fix: portalize popover & adjust default styling

### DIFF
--- a/src/components/Popover/Content.tsx
+++ b/src/components/Popover/Content.tsx
@@ -1,4 +1,7 @@
-import { Content as RadixPopoverContent } from "@radix-ui/react-popover";
+import {
+  Content as RadixPopoverContent,
+  Portal as RadixPopoverPortal,
+} from "@radix-ui/react-popover";
 import { classNames } from "~/utils";
 import { popover } from "./Popover.css";
 
@@ -18,8 +21,13 @@ export const Content = ({
   ...props
 }: PopoverContentProps) => {
   return (
-    <RadixPopoverContent className={classNames(popover, className)} {...props}>
-      {children}
-    </RadixPopoverContent>
+    <RadixPopoverPortal>
+      <RadixPopoverContent
+        className={classNames(popover, className)}
+        {...props}
+      >
+        {children}
+      </RadixPopoverContent>
+    </RadixPopoverPortal>
   );
 };

--- a/src/components/Popover/Portal.tsx
+++ b/src/components/Popover/Portal.tsx
@@ -1,9 +1,0 @@
-import { Portal as RadixPopoverPortal } from "@radix-ui/react-popover";
-
-export interface PopoverPortalProps {
-  children: React.ReactNode;
-}
-
-export const Portal = ({ children }: PopoverPortalProps) => {
-  return <RadixPopoverPortal>{children}</RadixPopoverPortal>;
-};

--- a/src/components/Popover/index.ts
+++ b/src/components/Popover/index.ts
@@ -2,14 +2,12 @@ import { Content } from "./Content";
 import { Anchor } from "./Anchor";
 import { Trigger } from "./Trigger";
 import { Arrow } from "./Arrow";
-import { Portal } from "./Portal";
 import { PopoverRoot } from "./Root";
 
 export type { PopoverContentProps } from "./Content";
 export type { PopoverAnchorProps } from "./Anchor";
 export type { PopoverTriggerProps } from "./Trigger";
 export type { PopoverArrowProps } from "./Arrow";
-export type { PopoverPortalProps } from "./Portal";
 export type { PopoverProps } from "./Root";
 
 export const Popover = Object.assign(PopoverRoot, {
@@ -17,5 +15,4 @@ export const Popover = Object.assign(PopoverRoot, {
   Content,
   Anchor,
   Arrow,
-  Portal,
 });


### PR DESCRIPTION
I want to merge this change because it:
- portalizes Popover.Content
- adds css adjsutments: padding, default background color and box-shadow property

This PR closes #393.

### Screenshots

Before         |  After
:-------------------------:|:-------------------------:
<img width="229" alt="image" src="https://user-images.githubusercontent.com/41952692/233937972-898817c9-c2a7-4dfa-80fa-e241aef4b8a2.png">  |  <img width="253" alt="image" src="https://user-images.githubusercontent.com/41952692/233938054-dff5cf10-a7d1-451d-9654-dd7a5e2f0107.png">

### Pull Request Checklist

- [x] New components are exported from `./src/components/index.ts`.
- [x] Storybook story is created and documentation properly generated.
