### PR TITLE
fix: apply default label variant

### DIFF
--- a/src/components/BaseInput/BaseInput.css.ts
+++ b/src/components/BaseInput/BaseInput.css.ts
@@ -135,6 +135,9 @@ export const labelRecipe = recipe({
       }),
     },
   ],
+  defaultVariants: {
+    size: "medium",
+  },
 });
 
 export const spanRecipe = recipe({


### PR DESCRIPTION
I want to merge this change because it applied default variant for `labelRecipe`


### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

- [ ] New components are exported from `./src/components/index.ts`.
- [ ] Storybook story is created and documentation properly generated.
