### PR TITLE
fix: allow passing external handlers to Input

### DIFF
--- a/src/components/Input/Input.stories.tsx
+++ b/src/components/Input/Input.stories.tsx
@@ -13,6 +13,8 @@ const meta: Meta<typeof Input> = {
   },
   argTypes: {
     onChange: { action: "onChange" },
+    onBlur: { action: "onBlur" },
+    onFocus: { action: "onFocus" },
   },
 };
 

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -33,6 +33,8 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
       error = false,
       onChange,
       helperText,
+      onBlur,
+      onFocus,
       ...props
     },
     ref
@@ -64,7 +66,17 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
             disabled={disabled}
             value={inputValue}
             ref={ref}
-            {...handlers}
+            onBlur={(event: React.FocusEvent<HTMLInputElement, Element>) => {
+              handlers.onBlur();
+              onBlur?.(event);
+            }}
+            onFocus={(event: React.FocusEvent<HTMLInputElement, Element>) => {
+              handlers.onFocus();
+              onFocus?.(event);
+            }}
+            onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+              handlers.onChange(event);
+            }}
             {...props}
           />
         </InputWrapper>

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, InputHTMLAttributes, ReactNode } from "react";
+import { forwardRef, InputHTMLAttributes, ReactNode, FocusEvent } from "react";
 
 import { classNames } from "~/utils";
 
@@ -66,17 +66,15 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
             disabled={disabled}
             value={inputValue}
             ref={ref}
-            onBlur={(event: React.FocusEvent<HTMLInputElement, Element>) => {
+            onBlur={(event: FocusEvent<HTMLInputElement, Element>) => {
               handlers.onBlur();
               onBlur?.(event);
             }}
-            onFocus={(event: React.FocusEvent<HTMLInputElement, Element>) => {
+            onFocus={(event: FocusEvent<HTMLInputElement, Element>) => {
               handlers.onFocus();
               onFocus?.(event);
             }}
-            onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-              handlers.onChange(event);
-            }}
+            onChange={handlers.onChange}
             {...props}
           />
         </InputWrapper>


### PR DESCRIPTION
I want to merge this change because it allows passing external handlers (e.g from forms libraries) into the `Input` component.

This PR closes #396 

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

- [ ] New components are exported from `./src/components/index.ts`.
- [x] Storybook story is created and documentation properly generated.
