### PR TITLE
fix: disable autocomplete color for 1pass

### DIFF
--- a/src/components/BaseInput/BaseInput.css.ts
+++ b/src/components/BaseInput/BaseInput.css.ts
@@ -213,7 +213,7 @@ export const inputRecipe = recipe({
         "&:focus::-moz-placeholder": {
           color: vars.colors.foreground.textNeutralSubdued,
         },
-        // disable chrome autocomplete background color
+        // disable autocomplete background colors
         "&:-webkit-autofill": {
           transition: "background-color 9999s ease-in-out 0s",
         },
@@ -224,6 +224,9 @@ export const inputRecipe = recipe({
           transition: "background-color 9999s ease-in-out 0s",
         },
         "&:-webkit-autofill:active": {
+          transition: "background-color 9999s ease-in-out 0s",
+        },
+        "&[data-com-onepassword-filled]": {
           transition: "background-color 9999s ease-in-out 0s",
         },
       },


### PR DESCRIPTION
I want to merge this change because it disables autocomplete background color coming from 1password.

### Screenshots

| Before | After |
| ------- | ------- |
| ![CleanShot 2023-04-27 at 09 59 31@2x](https://user-images.githubusercontent.com/9116238/234798150-7df1a665-963c-43ad-89b2-16ce22649a23.jpg) | ![CleanShot 2023-04-27 at 09 59 14@2x](https://user-images.githubusercontent.com/9116238/234798096-5f073add-8b0d-46bf-a779-a364b02c6dd7.jpg) |
  

### Pull Request Checklist

- [ ] New components are exported from `./src/components/index.ts`.
- [ ] Storybook story is created and documentation properly generated.
