### PR TITLE
fix: render popover content as child

### DIFF
--- a/src/components/Popover/Content.tsx
+++ b/src/components/Popover/Content.tsx
@@ -23,6 +23,7 @@ export const Content = ({
   return (
     <RadixPopoverPortal>
       <RadixPopoverContent
+        asChild
         className={classNames(popover, className)}
         {...props}
       >

--- a/src/components/Popover/Popover.css.ts
+++ b/src/components/Popover/Popover.css.ts
@@ -7,7 +7,6 @@ export const popover = sprinkles({
   borderColor: "neutralPlain",
   borderRadius: 3,
   boxShadow: "interactiveDefaultHovering",
-  padding: 5,
   backgroundColor: "subdued",
 });
 


### PR DESCRIPTION
I want to merge this change because it removes default padding from popover and renders the content as child. This will make it easier to apply custom styling.

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

- [ ] New components are exported from `./src/components/index.ts`.
- [ ] Storybook story is created and documentation properly generated.
