### PR TITLE
fix: make combobox controlled

### DIFF
--- a/src/components/Combobox/Combobox.stories.tsx
+++ b/src/components/Combobox/Combobox.stories.tsx
@@ -109,7 +109,7 @@ export const SmallHelperText: Story = {
 };
 
 export const Controlled = () => {
-  const [value, setValue] = useState("");
+  const [value, setValue] = useState<string | number | undefined>("");
 
   return (
     <Combobox
@@ -117,7 +117,7 @@ export const Controlled = () => {
       value={value}
       options={options}
       label="Pick a color"
-      onChange={(value) => setValue(value ?? "")}
+      onChange={(value) => setValue(value)}
     />
   );
 };

--- a/src/components/Combobox/Combobox.stories.tsx
+++ b/src/components/Combobox/Combobox.stories.tsx
@@ -1,14 +1,15 @@
+import { useState } from "react";
 import { Meta, StoryObj } from "@storybook/react";
 
 import { Combobox } from ".";
 
 const options = [
-  { value: "Black", label: "Black" },
-  { value: "Red", label: "Red" },
-  { value: "Green", label: "Green" },
-  { value: "Blue", label: "Blue" },
-  { value: "Orange", label: "Orange" },
-  { value: "Purple", label: "Purple" },
+  { value: "color-black", label: "Black" },
+  { value: "color-red", label: "Red" },
+  { value: "color-green", label: "Green" },
+  { value: "color-blue", label: "Blue" },
+  { value: "color-orange", label: "Orange" },
+  { value: "color-purple", label: "Purple" },
 ];
 
 const meta: Meta<typeof Combobox> = {
@@ -19,6 +20,7 @@ const meta: Meta<typeof Combobox> = {
     options,
     label: "Pick a color",
     id: "combobox",
+    value: "color-black",
   },
 };
 
@@ -104,4 +106,18 @@ export const SmallHelperText: Story = {
     ...Small.args,
     helperText: "Helper text",
   },
+};
+
+export const Controlled = () => {
+  const [value, setValue] = useState("");
+
+  return (
+    <Combobox
+      {...Large.args}
+      value={value}
+      options={options}
+      label="Pick a color"
+      onChange={(value) => setValue(value ?? "")}
+    />
+  );
 };

--- a/src/components/Combobox/Combobox.stories.tsx
+++ b/src/components/Combobox/Combobox.stories.tsx
@@ -109,7 +109,7 @@ export const SmallHelperText: Story = {
 };
 
 export const Controlled = () => {
-  const [value, setValue] = useState<string | number | undefined>("");
+  const [value, setValue] = useState("");
 
   return (
     <Combobox
@@ -117,7 +117,7 @@ export const Controlled = () => {
       value={value}
       options={options}
       label="Pick a color"
-      onChange={(value) => setValue(value)}
+      onChange={(value) => setValue(value as string)}
     />
   );
 };

--- a/src/components/Combobox/Combobox.tsx
+++ b/src/components/Combobox/Combobox.tsx
@@ -27,7 +27,7 @@ export type ComboboxProps = PropsWithBox<
     helperText?: ReactNode;
     options: Option[];
     onChange?: ChangeHandler;
-    value?: string;
+    value: Option["value"] | undefined;
   }
 > &
   InputVariants;
@@ -60,7 +60,7 @@ export const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(
       getInputProps,
       highlightedIndex,
       getItemProps,
-      items,
+      itemsToSelect,
     } = useComboboxEvents(value, options, onChange);
 
     return (
@@ -93,12 +93,12 @@ export const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(
 
         <Box
           position="relative"
-          display={isOpen ? "block" : "none"}
+          display={isOpen && itemsToSelect.length > 0 ? "block" : "none"}
           className={listWrapperRecipe({ size })}
         >
           <List as="ul" className={list} {...getMenuProps()}>
             {isOpen &&
-              items?.map((item, index) => (
+              itemsToSelect?.map((item, index) => (
                 <List.Item
                   key={`${id}-${item}-${index}`}
                   className={listItem}

--- a/src/components/Combobox/Combobox.tsx
+++ b/src/components/Combobox/Combobox.tsx
@@ -2,7 +2,12 @@ import { forwardRef, InputHTMLAttributes, ReactNode } from "react";
 
 import { classNames } from "~/utils";
 
-import { Option, ChangeHandler, useComboboxEvents } from "./useComboboxEvents";
+import {
+  Option,
+  ChangeHandler,
+  useComboboxEvents,
+  InputValue,
+} from "./useComboboxEvents";
 import { ComboboxWrapper } from "./ComboboxWrapper";
 import { List, Text, Box, PropsWithBox } from "..";
 import { helperTextRecipe, inputRecipe, InputVariants } from "../BaseInput";
@@ -27,7 +32,7 @@ export type ComboboxProps = PropsWithBox<
     helperText?: ReactNode;
     options: Option[];
     onChange?: ChangeHandler;
-    value: Option["value"] | undefined;
+    value: InputValue;
   }
 > &
   InputVariants;

--- a/src/components/Combobox/ComboboxWrapper.tsx
+++ b/src/components/Combobox/ComboboxWrapper.tsx
@@ -70,5 +70,3 @@ export const ComboboxWrapper = ({
     </Box>
   );
 };
-
-ComboboxWrapper.displayName = "InputWrapper";

--- a/src/components/Combobox/useComboboxEvents.tsx
+++ b/src/components/Combobox/useComboboxEvents.tsx
@@ -5,14 +5,11 @@ import {
   UseComboboxGetInputPropsOptions,
 } from "downshift7";
 
-export type InputValue = string | undefined | number;
+export type InputValue = string | number;
 export type ChangeHandler = (selectedItem: InputValue) => void;
 export type Option = { label: string; value: NonNullable<InputValue> };
 
-const getItemsFilter = (
-  inputValue: string | undefined | number,
-  options: Option[]
-) => {
+const getItemsFilter = (inputValue: string | number, options: Option[]) => {
   if (!inputValue) {
     return options;
   }
@@ -47,10 +44,14 @@ export const useComboboxEvents = (
     itemToString: (item) => item?.label ?? "",
     selectedItem: options.find((option) => option.value === value) ?? null,
     onSelectedItemChange: ({ selectedItem }) => {
-      changeHandler?.(selectedItem?.value ?? "");
+      if (selectedItem) {
+        changeHandler?.(selectedItem?.value);
+      }
     },
     onInputValueChange: ({ inputValue }) => {
-      setInputValue(inputValue);
+      if (inputValue) {
+        setInputValue(inputValue);
+      }
     },
   });
 

--- a/src/components/Combobox/useComboboxEvents.tsx
+++ b/src/components/Combobox/useComboboxEvents.tsx
@@ -6,18 +6,19 @@ import {
 } from "downshift7";
 
 type InputValue = string | undefined;
-export type ChangeHandler = (selectedItem: Option | null | undefined) => void;
+export type ChangeHandler = (selectedItem: string | null | undefined) => void;
 export type Option = { label: string; value: string };
 
-const getItemsFilter = (inputValue: InputValue) => {
+const getItemsFilter = (inputValue: InputValue, options: Option[]) => {
   if (!inputValue) {
-    return () => false;
+    return options;
   }
 
   const lowerCasedInputValue = inputValue.toLowerCase();
 
-  return (item: Option) =>
-    !inputValue || item.label.toLowerCase().includes(lowerCasedInputValue);
+  return options.filter((option) =>
+    option.label.toLowerCase().includes(lowerCasedInputValue)
+  );
 };
 
 export const useComboboxEvents = (
@@ -25,10 +26,10 @@ export const useComboboxEvents = (
   options: Option[],
   changeHandler?: ChangeHandler
 ) => {
-  const [inputValue, setInputValue] = useState(value);
-  const [items, setItemOptions] = useState(options);
+  const [inputValue, setInputValue] = useState<InputValue>(value);
   const [active, setActive] = useState(false);
-  const typed = Boolean(inputValue || active);
+  const typed = Boolean(value || active);
+  const itemsToSelect = getItemsFilter(inputValue, options);
 
   const {
     isOpen,
@@ -39,22 +40,15 @@ export const useComboboxEvents = (
     highlightedIndex,
     getItemProps,
   } = useCombobox({
-    items,
+    items: itemsToSelect,
     itemToString: (item) => item?.label ?? "",
-    onSelectedItemChange: (changes) => {
-      if (changeHandler) {
-        changeHandler(changes.selectedItem);
-      }
+    selectedItem: options.find((option) => option.value === value) ?? null,
+    onSelectedItemChange: ({ selectedItem }) => {
+      changeHandler?.(selectedItem?.value);
     },
     onInputValueChange: ({ inputValue }) => {
       setInputValue(inputValue);
-      if (!inputValue) {
-        setItemOptions(options);
-      } else {
-        setItemOptions(items.filter(getItemsFilter(inputValue)));
-      }
     },
-    defaultInputValue: value,
   });
 
   const onFocus = () => setActive(true);
@@ -62,7 +56,7 @@ export const useComboboxEvents = (
 
   return {
     active,
-    items,
+    itemsToSelect,
     typed,
     isOpen,
     getToggleButtonProps,

--- a/src/components/Combobox/useComboboxEvents.tsx
+++ b/src/components/Combobox/useComboboxEvents.tsx
@@ -7,9 +7,12 @@ import {
 
 export type InputValue = string | number;
 export type ChangeHandler = (selectedItem: InputValue) => void;
-export type Option = { label: string; value: NonNullable<InputValue> };
+export type Option = { label: string; value: InputValue };
 
-const getItemsFilter = (inputValue: string | number, options: Option[]) => {
+const getItemsFilter = (
+  inputValue: InputValue | undefined,
+  options: Option[]
+) => {
   if (!inputValue) {
     return options;
   }
@@ -26,7 +29,7 @@ export const useComboboxEvents = (
   options: Option[],
   changeHandler?: ChangeHandler
 ) => {
-  const [inputValue, setInputValue] = useState<InputValue>(value);
+  const [inputValue, setInputValue] = useState<InputValue | undefined>(value);
   const [active, setActive] = useState(false);
   const typed = Boolean(value || active);
   const itemsToSelect = getItemsFilter(inputValue, options);
@@ -49,9 +52,7 @@ export const useComboboxEvents = (
       }
     },
     onInputValueChange: ({ inputValue }) => {
-      if (inputValue) {
-        setInputValue(inputValue);
-      }
+      setInputValue(inputValue);
     },
   });
 

--- a/src/components/Combobox/useComboboxEvents.tsx
+++ b/src/components/Combobox/useComboboxEvents.tsx
@@ -5,16 +5,19 @@ import {
   UseComboboxGetInputPropsOptions,
 } from "downshift7";
 
-type InputValue = string | undefined;
-export type ChangeHandler = (selectedItem: string | null | undefined) => void;
-export type Option = { label: string; value: string };
+export type InputValue = string | undefined | number;
+export type ChangeHandler = (selectedItem: InputValue) => void;
+export type Option = { label: string; value: NonNullable<InputValue> };
 
-const getItemsFilter = (inputValue: InputValue, options: Option[]) => {
+const getItemsFilter = (
+  inputValue: string | undefined | number,
+  options: Option[]
+) => {
   if (!inputValue) {
     return options;
   }
 
-  const lowerCasedInputValue = inputValue.toLowerCase();
+  const lowerCasedInputValue = inputValue.toString().toLowerCase();
 
   return options.filter((option) =>
     option.label.toLowerCase().includes(lowerCasedInputValue)
@@ -44,7 +47,7 @@ export const useComboboxEvents = (
     itemToString: (item) => item?.label ?? "",
     selectedItem: options.find((option) => option.value === value) ?? null,
     onSelectedItemChange: ({ selectedItem }) => {
-      changeHandler?.(selectedItem?.value);
+      changeHandler?.(selectedItem?.value ?? "");
     },
     onInputValueChange: ({ inputValue }) => {
       setInputValue(inputValue);


### PR DESCRIPTION
I want to merge this change because it makes the `<Combobox/>` component controlled. I also changed the signature of the `onChange` function - now it will return only the selected value not the full `Option` object.


### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

- [ ] New components are exported from `./src/components/index.ts`.
- [x] Storybook story is created and documentation properly generated.
