### PR TITLE
fix: rework accordion structure and add disabled state

### DIFF
--- a/src/components/Accordion/Accordion.stories.tsx
+++ b/src/components/Accordion/Accordion.stories.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-key */
 import { Meta, StoryObj } from "@storybook/react";
 import { Text } from "../..";
 
@@ -18,27 +19,25 @@ export const Primary: Story = {
     display: "flex",
     gap: 5,
     flexDirection: "column",
-    children: (
-      <>
-        <Accordion.Item value="first-item">
-          <Accordion.Trigger>
-            <Text>Trigger 1</Text>
-          </Accordion.Trigger>
-          <Accordion.Content>Content 1</Accordion.Content>
-        </Accordion.Item>
-        <Accordion.Item value="second-item">
-          <Accordion.Trigger>
-            <Text>Trigger 2</Text>
-          </Accordion.Trigger>
-          <Accordion.Content>Content 2</Accordion.Content>
-        </Accordion.Item>
-        <Accordion.Item value="third-item">
-          <Accordion.Trigger disabled>
-            <Text color="textNeutralDisabled">Trigger 3</Text>
-          </Accordion.Trigger>
-          <Accordion.Content>Content 3</Accordion.Content>
-        </Accordion.Item>
-      </>
-    ),
+    children: [
+      <Accordion.Item value="first-item">
+        <Accordion.Trigger>
+          <Text>Trigger 1</Text>
+        </Accordion.Trigger>
+        <Accordion.Content>Content 1</Accordion.Content>
+      </Accordion.Item>,
+      <Accordion.Item value="second-item">
+        <Accordion.Trigger>
+          <Text>Trigger 2</Text>
+        </Accordion.Trigger>
+        <Accordion.Content>Content 2</Accordion.Content>
+      </Accordion.Item>,
+      <Accordion.Item value="third-item">
+        <Accordion.Trigger disabled>
+          <Text color="textNeutralDisabled">Trigger 3</Text>
+        </Accordion.Trigger>
+        <Accordion.Content>Content 3</Accordion.Content>
+      </Accordion.Item>,
+    ],
   },
 };

--- a/src/components/Accordion/Accordion.stories.tsx
+++ b/src/components/Accordion/Accordion.stories.tsx
@@ -1,5 +1,7 @@
 import { Meta, StoryObj } from "@storybook/react";
-import { Accordion } from "./index";
+import { Text } from "../..";
+
+import { Accordion } from ".";
 
 const meta: Meta<typeof Accordion> = {
   title: "Components / Accordion",
@@ -16,17 +18,27 @@ export const Primary: Story = {
     display: "flex",
     gap: 5,
     flexDirection: "column",
-    children: [
-      // eslint-disable-next-line react/jsx-key
-      <Accordion.Item value="first-item">
-        <Accordion.Item.Trigger>Trigger 1</Accordion.Item.Trigger>
-        <Accordion.Item.Content>Content 1</Accordion.Item.Content>
-      </Accordion.Item>,
-      // eslint-disable-next-line react/jsx-key
-      <Accordion.Item value="second-item">
-        <Accordion.Item.Trigger>Trigger 2</Accordion.Item.Trigger>
-        <Accordion.Item.Content>Content 2</Accordion.Item.Content>
-      </Accordion.Item>,
-    ],
+    children: (
+      <>
+        <Accordion.Item value="first-item">
+          <Accordion.Trigger>
+            <Text>Trigger 1</Text>
+          </Accordion.Trigger>
+          <Accordion.Content>Content 1</Accordion.Content>
+        </Accordion.Item>
+        <Accordion.Item value="second-item">
+          <Accordion.Trigger>
+            <Text>Trigger 2</Text>
+          </Accordion.Trigger>
+          <Accordion.Content>Content 2</Accordion.Content>
+        </Accordion.Item>
+        <Accordion.Item value="third-item">
+          <Accordion.Trigger disabled>
+            <Text color="textNeutralDisabled">Trigger 3</Text>
+          </Accordion.Trigger>
+          <Accordion.Content>Content 3</Accordion.Content>
+        </Accordion.Item>
+      </>
+    ),
   },
 };

--- a/src/components/Accordion/Item/Content.tsx
+++ b/src/components/Accordion/Item/Content.tsx
@@ -4,11 +4,11 @@ import { ReactNode } from "react";
 import { Box, PropsWithBox } from "~/components/Box";
 import { content } from "../common.css";
 
-export type AccordionProps = PropsWithBox<{
+export type AccordionContentProps = PropsWithBox<{
   children: ReactNode;
 }>;
 
-export const Content = ({ children, ...rest }: AccordionProps) => (
+export const Content = ({ children, ...rest }: AccordionContentProps) => (
   <AccordionContent asChild className={content}>
     <Box {...rest}>{children}</Box>
   </AccordionContent>

--- a/src/components/Accordion/Item/Content.tsx
+++ b/src/components/Accordion/Item/Content.tsx
@@ -13,3 +13,5 @@ export const Content = ({ children, ...rest }: AccordionContentProps) => (
     <Box {...rest}>{children}</Box>
   </AccordionContent>
 );
+
+Content.displayName = "Accordion.Content";

--- a/src/components/Accordion/Item/Item.tsx
+++ b/src/components/Accordion/Item/Item.tsx
@@ -17,3 +17,5 @@ export const Item = ({ children, value, ...rest }: AccordionItemProps) => {
     </AccordionItem>
   );
 };
+
+Item.displayName = "Accordion.Item";

--- a/src/components/Accordion/Item/Item.tsx
+++ b/src/components/Accordion/Item/Item.tsx
@@ -10,7 +10,7 @@ export type AccordionItemProps = PropsWithBox<{
   value: string;
 }>;
 
-export const Root = ({ children, value, ...rest }: AccordionItemProps) => {
+export const Item = ({ children, value, ...rest }: AccordionItemProps) => {
   return (
     <AccordionItem value={value} className={trigger} asChild>
       <Box {...rest}>{children}</Box>

--- a/src/components/Accordion/Item/Trigger.tsx
+++ b/src/components/Accordion/Item/Trigger.tsx
@@ -9,7 +9,7 @@ import { Button } from "../../Button";
 import { ChervonDownIcon } from "../../Icons";
 import { icon } from "../common.css";
 
-export type AccordionProps = PropsWithBox<{
+export type AccordionTriggerProps = PropsWithBox<{
   children: ReactNode;
   buttonDataTestId?: string;
 }>;
@@ -17,16 +17,23 @@ export type AccordionProps = PropsWithBox<{
 export const Trigger = ({
   children,
   buttonDataTestId,
+  disabled,
   ...rest
-}: AccordionProps) => (
+}: AccordionTriggerProps) => (
   <AccordionHeader asChild>
-    <AccordionTrigger asChild>
+    <AccordionTrigger
+      asChild
+      onClick={(e) => {
+        disabled && e.preventDefault();
+      }}
+    >
       <Box
         display="flex"
         justifyContent="space-between"
         gap={5}
         alignItems="center"
-        cursor="pointer"
+        cursor={disabled ? "not-allowed" : "pointer"}
+        disabled={disabled}
         {...rest}
       >
         {children}
@@ -35,6 +42,7 @@ export const Trigger = ({
           variant="secondary"
           type="button"
           data-test-id={buttonDataTestId}
+          disabled={disabled}
         />
       </Box>
     </AccordionTrigger>

--- a/src/components/Accordion/Item/Trigger.tsx
+++ b/src/components/Accordion/Item/Trigger.tsx
@@ -48,3 +48,5 @@ export const Trigger = ({
     </AccordionTrigger>
   </AccordionHeader>
 );
+
+Trigger.displayName = "Accordion.Trigger";

--- a/src/components/Accordion/Item/index.ts
+++ b/src/components/Accordion/Item/index.ts
@@ -1,5 +1,3 @@
-import { Trigger } from "./Trigger";
-import { Content } from "./Content";
-import { Root } from "./Root";
-
-export const Item = Object.assign(Root, { Trigger, Content });
+export * from "./Item";
+export * from "./Trigger";
+export * from "./Content";

--- a/src/components/Accordion/index.ts
+++ b/src/components/Accordion/index.ts
@@ -1,4 +1,4 @@
 import { Root } from "./Root";
-import { Item } from "./Item";
+import { Content, Item, Trigger } from "./Item";
 
-export const Accordion = Object.assign(Root, { Item });
+export const Accordion = Object.assign(Root, { Item, Trigger, Content });


### PR DESCRIPTION
I want to merge this change because it adds a disabled state and after feedback from developers refactor the Accordion structure. You can see changes in table under:

| Before | After |
| ------- | ------- |
| `Accordion.Item.Trigger` | `Accordion.Trigger` |
| `Accordion.Item.Content` | `Accordion.Content` |


This PR closes #406

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->
![CleanShot 2023-04-27 at 15 30 07@2x](https://user-images.githubusercontent.com/9116238/234877234-2ea693bb-5d7b-4c63-a33c-af2c588c6587.jpg)

### Pull Request Checklist

- [ ] New components are exported from `./src/components/index.ts`.
- [x] Storybook story is created and documentation properly generated.
