### PR TITLE
docs: cleanup controlled stories & remove not needed token

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,5 +41,4 @@ jobs:
       - name: Publish to Chromatic
         uses: chromaui/action@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -80,6 +80,22 @@ export default class AppDocument extends Document {
 }
 ```
 
+### Usage with form libraries
+
+#### React Hook Form
+
+You need to wrap the MacawUI component with [`Controller`](https://react-hook-form.com/api/usecontroller/controller/). For example:
+
+```tsx
+import { Input } from "@saleor/macaw-ui/next";
+
+<Controller
+  control={control}
+  name="name-input"
+  render={({ field }) => <Input {...field} />}
+/>;
+```
+
 ### Development
 
 To begin, you need to install dependencies:

--- a/src/components/Combobox/Combobox.stories.tsx
+++ b/src/components/Combobox/Combobox.stories.tsx
@@ -20,104 +20,49 @@ const meta: Meta<typeof Combobox> = {
     options,
     label: "Pick a color",
     id: "combobox",
-    value: "color-black",
+    size: "large",
   },
 };
 
 export default meta;
 type Story = StoryObj<typeof Combobox>;
 
-export const Large: Story = {
-  args: {
-    size: "large",
+const ComboboxTemplate: Story = {
+  render: (args) => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const [value, setValue] = useState(options[0].value);
+
+    return (
+      <Combobox
+        {...args}
+        value={value}
+        onChange={(value) => setValue(value as string)}
+      />
+    );
   },
 };
 
-export const Medium: Story = {
-  args: {
-    size: "medium",
-  },
+export const Default: Story = {
+  ...ComboboxTemplate,
 };
 
-export const Small: Story = {
+export const Error: Story = {
+  ...ComboboxTemplate,
   args: {
-    size: "small",
-  },
-};
-
-export const LargeError: Story = {
-  args: {
-    ...Large.args,
     error: true,
   },
 };
 
-export const MediumError: Story = {
+export const Disabled: Story = {
+  ...ComboboxTemplate,
   args: {
-    ...Medium.args,
-    error: true,
-  },
-};
-
-export const SmallError: Story = {
-  args: {
-    ...Small.args,
-    error: true,
-  },
-};
-
-export const LargeDisabled: Story = {
-  args: {
-    ...Large.args,
     disabled: true,
   },
 };
 
-export const MediumDisabled: Story = {
+export const WithHelperText: Story = {
+  ...ComboboxTemplate,
   args: {
-    ...Medium.args,
-    disabled: true,
-  },
-};
-
-export const SmallDisabled: Story = {
-  args: {
-    ...Small.args,
-    disabled: true,
-  },
-};
-
-export const LargeHelperText: Story = {
-  args: {
-    ...Large.args,
     helperText: "Helper text",
   },
-};
-
-export const MediumHelperText: Story = {
-  args: {
-    ...Medium.args,
-    helperText: "Helper text",
-  },
-};
-
-export const SmallHelperText: Story = {
-  args: {
-    ...Small.args,
-    helperText: "Helper text",
-  },
-};
-
-export const Controlled = () => {
-  const [value, setValue] = useState("");
-
-  return (
-    <Combobox
-      {...Large.args}
-      value={value}
-      options={options}
-      label="Pick a color"
-      onChange={(value) => setValue(value as string)}
-    />
-  );
 };

--- a/src/components/Input/Input.stories.tsx
+++ b/src/components/Input/Input.stories.tsx
@@ -24,9 +24,9 @@ const InputTemplate: Story = {
 
     return (
       <Input
+        {...args}
         value={value}
         onChange={(e) => setValue(e.target.value)}
-        {...args}
       />
     );
   },

--- a/src/components/Input/Input.stories.tsx
+++ b/src/components/Input/Input.stories.tsx
@@ -1,4 +1,6 @@
+import { useState } from "react";
 import { Meta, StoryObj } from "@storybook/react";
+
 import { Input } from "./index";
 
 const meta: Meta<typeof Input> = {
@@ -6,30 +8,43 @@ const meta: Meta<typeof Input> = {
   tags: ["autodocs"],
   component: Input,
   args: {
-    value: "Input content",
     label: "Label",
     size: "large",
     placeholder: "Input placeholder",
-  },
-  argTypes: {
-    onChange: { action: "onChange" },
-    onBlur: { action: "onBlur" },
-    onFocus: { action: "onFocus" },
   },
 };
 
 export default meta;
 type Story = StoryObj<typeof Input>;
 
-export const Primary: Story = {};
+const InputTemplate: Story = {
+  render: (args) => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const [value, setValue] = useState("Input content");
+
+    return (
+      <Input
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        {...args}
+      />
+    );
+  },
+};
+
+export const Default: Story = {
+  ...InputTemplate,
+};
 
 export const Errored: Story = {
+  ...InputTemplate,
   args: {
     error: true,
   },
 };
 
 export const Disabled: Story = {
+  ...InputTemplate,
   args: {
     disabled: true,
   },


### PR DESCRIPTION
I want to merge this change because it cleanups controlled input (`Input` & `Combobox`) stories and removes not needed GitHub token from the chromatic workflow.


### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

- [ ] New components are exported from `./src/components/index.ts`.
- [ ] Storybook story is created and documentation properly generated.
