### PR TITLE
fix: add ref to tooltip trigger

### DIFF
--- a/src/components/Tooltip/Trigger.tsx
+++ b/src/components/Tooltip/Trigger.tsx
@@ -1,10 +1,19 @@
-import { ReactNode } from "react";
+import { ReactNode, forwardRef } from "react";
 import { Trigger as RadixTooltipTrigger } from "@radix-ui/react-tooltip";
 
 export interface TooltipTriggerProps {
   children: ReactNode;
+  onFocus?: () => void;
 }
 
-export const Trigger = ({ children }: TooltipTriggerProps) => {
-  return <RadixTooltipTrigger asChild>{children}</RadixTooltipTrigger>;
-};
+export const Trigger = forwardRef<HTMLButtonElement, TooltipTriggerProps>(
+  ({ children, onFocus }, ref) => {
+    return (
+      <RadixTooltipTrigger asChild ref={ref} onFocus={onFocus}>
+        {children}
+      </RadixTooltipTrigger>
+    );
+  }
+);
+
+Trigger.displayName = "TooltipTrigger";

--- a/src/components/Tooltip/Trigger.tsx
+++ b/src/components/Tooltip/Trigger.tsx
@@ -3,13 +3,12 @@ import { Trigger as RadixTooltipTrigger } from "@radix-ui/react-tooltip";
 
 export interface TooltipTriggerProps {
   children: ReactNode;
-  onFocus?: () => void;
 }
 
 export const Trigger = forwardRef<HTMLButtonElement, TooltipTriggerProps>(
-  ({ children, onFocus }, ref) => {
+  ({ children }, ref) => {
     return (
-      <RadixTooltipTrigger asChild ref={ref} onFocus={onFocus}>
+      <RadixTooltipTrigger asChild ref={ref}>
         {children}
       </RadixTooltipTrigger>
     );


### PR DESCRIPTION
I want to merge this change because it adds a missing ref to the tooltip trigger

This PR closes #...

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

- [ ] New components are exported from `./src/components/index.ts`.
- [ ] Storybook story is created and documentation properly generated.
