### PR TITLE
docs: adjust component naming

### DIFF
--- a/src/components/Avatar/Avatar.stories.tsx
+++ b/src/components/Avatar/Avatar.stories.tsx
@@ -3,8 +3,6 @@ import { Avatar } from "./index";
 
 const User = Avatar.User;
 const Store = Avatar.Store;
-Object.assign(User, { displayName: "Avatar.User" });
-Object.assign(Store, { displayName: "Avatar.Store" });
 
 const meta: Meta<typeof Avatar> = {
   title: "Components / Avatar",

--- a/src/components/Avatar/Store/Store.tsx
+++ b/src/components/Avatar/Store/Store.tsx
@@ -41,3 +41,5 @@ export const Store = (props: StoreAvatarProps) => {
     </Box>
   );
 };
+
+Store.displayName = "Avatar.Store";

--- a/src/components/Avatar/User/User.tsx
+++ b/src/components/Avatar/User/User.tsx
@@ -41,3 +41,5 @@ export const User = (props: UserAvatarProps) => {
     </Box>
   );
 };
+
+User.displayName = "Avatar.User";

--- a/src/components/Combobox/Combobox.stories.tsx
+++ b/src/components/Combobox/Combobox.stories.tsx
@@ -44,12 +44,45 @@ const ComboboxTemplate: Story = {
 
 export const Default: Story = {
   ...ComboboxTemplate,
+  parameters: {
+    docs: {
+      source: {
+        code: `
+  const [value, setValue] = useState("color-black");
+  
+  <Combobox
+    label="Label"
+    size="large"
+    value={value}
+    onChange={(e) => setValue(value)}
+    options={[{ value: "color-black", label: "Black" }]}
+  />`,
+      },
+    },
+  },
 };
 
 export const Error: Story = {
   ...ComboboxTemplate,
   args: {
     error: true,
+  },
+  parameters: {
+    docs: {
+      source: {
+        code: `
+  const [value, setValue] = useState("color-black");
+  
+  <Combobox
+    label="Label"
+    size="large"
+    value={value}
+    onChange={(e) => setValue(value)}
+    options={[{ value: "color-black", label: "Black" }]}
+    error
+  />`,
+      },
+    },
   },
 };
 
@@ -58,11 +91,45 @@ export const Disabled: Story = {
   args: {
     disabled: true,
   },
+  parameters: {
+    docs: {
+      source: {
+        code: `
+  const [value, setValue] = useState("color-black");
+  
+  <Combobox
+    label="Label"
+    size="large"
+    value={value}
+    onChange={(e) => setValue(value)}
+    options={[{ value: "color-black", label: "Black" }]}
+    disabled
+  />`,
+      },
+    },
+  },
 };
 
 export const WithHelperText: Story = {
   ...ComboboxTemplate,
   args: {
     helperText: "Helper text",
+  },
+  parameters: {
+    docs: {
+      source: {
+        code: `
+  const [value, setValue] = useState("color-black");
+  
+  <Combobox
+    label="Label"
+    size="large"
+    value={value}
+    onChange={(e) => setValue(value)}
+    options={[{ value: "color-black", label: "Black" }]}
+    helperText="Helper text"
+  />`,
+      },
+    },
   },
 };

--- a/src/components/Drawer/Content.tsx
+++ b/src/components/Drawer/Content.tsx
@@ -46,3 +46,5 @@ export const Content = ({ children, ...rest }: DrawerContentProps) => {
     </Dialog.Portal>
   );
 };
+
+Content.displayName = "Drawer.Content";

--- a/src/components/Drawer/Root.tsx
+++ b/src/components/Drawer/Root.tsx
@@ -7,3 +7,5 @@ export type DrawerRootProps = {
 export const Root = ({ children }: DrawerRootProps) => {
   return <DialogRoot>{children}</DialogRoot>;
 };
+
+Root.displayName = "Drawer";

--- a/src/components/Drawer/Trigger.tsx
+++ b/src/components/Drawer/Trigger.tsx
@@ -7,3 +7,5 @@ export type DrawerTriggerProps = {
 export const Trigger = ({ children }: DrawerTriggerProps) => {
   return <DialogTrigger asChild>{children}</DialogTrigger>;
 };
+
+Trigger.displayName = "Drawer.Trigger";

--- a/src/components/Dropdown/Content.tsx
+++ b/src/components/Dropdown/Content.tsx
@@ -22,3 +22,5 @@ export const Content = ({ children, ...rest }: DropdownContentProps) => {
     </DropdownMenuPortal>
   );
 };
+
+Content.displayName = "Dropdown.Content";

--- a/src/components/Dropdown/Item.tsx
+++ b/src/components/Dropdown/Item.tsx
@@ -14,3 +14,5 @@ export const Item = ({ children }: ItemProps) => {
     </DropdownMenuItem>
   );
 };
+
+Item.displayName = "Dropdown.Item";

--- a/src/components/Dropdown/Root.tsx
+++ b/src/components/Dropdown/Root.tsx
@@ -18,3 +18,5 @@ export const DropdownRoot = ({
     </DropdownMenuRoot>
   );
 };
+
+DropdownRoot.displayName = "Dropdown";

--- a/src/components/Dropdown/Trigger.tsx
+++ b/src/components/Dropdown/Trigger.tsx
@@ -8,3 +8,5 @@ export type DropdownTriggerProps = {
 export const Trigger = ({ children }: DropdownTriggerProps) => {
   return <DropdownMenuTrigger asChild>{children}</DropdownMenuTrigger>;
 };
+
+Trigger.displayName = "Dropdown.Trigger";

--- a/src/components/Input/Input.stories.tsx
+++ b/src/components/Input/Input.stories.tsx
@@ -10,7 +10,6 @@ const meta: Meta<typeof Input> = {
   args: {
     label: "Label",
     size: "large",
-    placeholder: "Input placeholder",
   },
 };
 
@@ -34,6 +33,21 @@ const InputTemplate: Story = {
 
 export const Default: Story = {
   ...InputTemplate,
+  parameters: {
+    docs: {
+      source: {
+        code: `
+  const [value, setValue] = useState("Input content");
+
+  <Input
+    label="Label"
+    size="large"
+    value={value}
+    onChange={(e) => setValue(e.target.value)}
+  />`,
+      },
+    },
+  },
 };
 
 export const Errored: Story = {
@@ -41,11 +55,66 @@ export const Errored: Story = {
   args: {
     error: true,
   },
+  parameters: {
+    docs: {
+      source: {
+        code: `
+  const [value, setValue] = useState("Input content");
+  
+  <Input
+    label="Label"
+    size="large"
+    value={value}
+    onChange={(e) => setValue(e.target.value)}
+    error
+  />`,
+      },
+    },
+  },
 };
 
 export const Disabled: Story = {
   ...InputTemplate,
   args: {
     disabled: true,
+  },
+  parameters: {
+    docs: {
+      source: {
+        code: `
+  const [value, setValue] = useState("Input content");
+  
+  <Input
+    label="Label"
+    size="large"
+    value={value}
+    onChange={(e) => setValue(e.target.value)}
+    disabled
+  />`,
+      },
+    },
+  },
+};
+
+export const WithHelpText: Story = {
+  ...InputTemplate,
+  args: {
+    helperText: "Helper text",
+  },
+  parameters: {
+    docs: {
+      source: {
+        code: `
+  const [value, setValue] = useState("Input content");
+  
+  <Input
+    label="Label"
+    size="large"
+    value={value}
+    onChange={(e) => setValue(e.target.value)}
+    helperText="Helper text"
+  />`,
+      },
+    },
   },
 };

--- a/src/components/List/ItemGroup/Content.tsx
+++ b/src/components/List/ItemGroup/Content.tsx
@@ -4,3 +4,5 @@ import { ReactNode } from "react";
 export const Content = ({ children }: { children: ReactNode }) => {
   return <AccordionContent asChild>{children}</AccordionContent>;
 };
+
+Content.displayName = "ListItem.Content";

--- a/src/components/List/ItemGroup/Root.tsx
+++ b/src/components/List/ItemGroup/Root.tsx
@@ -45,3 +45,5 @@ export const ItemGroupRoot = ({
     </AccordionRoot>
   );
 };
+
+ItemGroupRoot.displayName = "ListItem";

--- a/src/components/List/ItemGroup/Trigger.tsx
+++ b/src/components/List/ItemGroup/Trigger.tsx
@@ -44,3 +44,5 @@ export const Trigger = ({ children, size, ...rest }: ItemGroupTriggerProps) => {
     </List.Item>
   );
 };
+
+Trigger.displayName = "ListItem.Trigger";

--- a/src/components/Popover/Anchor.tsx
+++ b/src/components/Popover/Anchor.tsx
@@ -7,3 +7,5 @@ export interface PopoverAnchorProps {
 export const Anchor = ({ children }: PopoverAnchorProps) => {
   return <RadixPopoverAnchor asChild>{children}</RadixPopoverAnchor>;
 };
+
+Anchor.displayName = "Popover.Anchor";

--- a/src/components/Popover/Arrow.tsx
+++ b/src/components/Popover/Arrow.tsx
@@ -33,3 +33,5 @@ export const Arrow = ({
     </RadixPopoverArrow>
   );
 };
+
+Arrow.displayName = "Popover.Arrow";

--- a/src/components/Popover/Content.tsx
+++ b/src/components/Popover/Content.tsx
@@ -32,3 +32,5 @@ export const Content = ({
     </RadixPopoverPortal>
   );
 };
+
+Content.displayName = "Popover.Content";

--- a/src/components/Popover/Root.tsx
+++ b/src/components/Popover/Root.tsx
@@ -11,3 +11,5 @@ export type PopoverProps = {
 export const PopoverRoot = ({ children, ...props }: PopoverProps) => {
   return <RadixPopoverRoot {...props}>{children}</RadixPopoverRoot>;
 };
+
+PopoverRoot.displayName = "Popover";

--- a/src/components/Popover/Trigger.tsx
+++ b/src/components/Popover/Trigger.tsx
@@ -7,3 +7,5 @@ export interface PopoverTriggerProps {
 export const Trigger = ({ children }: PopoverTriggerProps) => {
   return <RadixPopoverTrigger asChild>{children}</RadixPopoverTrigger>;
 };
+
+Trigger.displayName = "Popover.Trigger";

--- a/src/components/Tooltip/Arrow.tsx
+++ b/src/components/Tooltip/Arrow.tsx
@@ -32,3 +32,5 @@ export const Arrow = ({
     </RadixTooltipArrow>
   );
 };
+
+Arrow.displayName = "Tooltip.Arrow";

--- a/src/components/Tooltip/Content.tsx
+++ b/src/components/Tooltip/Content.tsx
@@ -36,3 +36,5 @@ export const Content = ({
     </RadixTooltipPortal>
   );
 };
+
+Content.displayName = "Tooltip.Content";

--- a/src/components/Tooltip/ContentHeading.tsx
+++ b/src/components/Tooltip/ContentHeading.tsx
@@ -17,3 +17,5 @@ export const ContentHeading = ({ children }: TooltipContentHeadingProps) => {
     </Text>
   );
 };
+
+ContentHeading.displayName = "Tooltip.ContentHeading";

--- a/src/components/Tooltip/Root.tsx
+++ b/src/components/Tooltip/Root.tsx
@@ -26,3 +26,5 @@ export const TooltipRoot = ({
     </RadixTooltipProvider>
   );
 };
+
+TooltipRoot.displayName = "Tooltip";

--- a/src/components/Tooltip/Trigger.tsx
+++ b/src/components/Tooltip/Trigger.tsx
@@ -15,4 +15,4 @@ export const Trigger = forwardRef<HTMLButtonElement, TooltipTriggerProps>(
   }
 );
 
-Trigger.displayName = "TooltipTrigger";
+Trigger.displayName = "Tooltip.Trigger";


### PR DESCRIPTION
I want to merge this change because of it:
1) fixes component naming for storybook snippets
1) adds proper code snippets for `Input` & `Combobox` components


### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->
![CleanShot 2023-05-09 at 09 25 40@2x](https://user-images.githubusercontent.com/9116238/237024669-4f662408-2b0d-4f61-8d4d-9cc7cc69d78f.jpg)
![CleanShot 2023-05-09 at 09 25 57@2x](https://user-images.githubusercontent.com/9116238/237024716-342fb3f3-c720-4514-9b95-df613f1e6c06.jpg)

### Pull Request Checklist

- [ ] New components are exported from `./src/components/index.ts`.
- [ ] Storybook story is created and documentation properly generated.
