### PR TITLE
feat(RadioGroup): add fieldset and legend (label)

### DIFF
--- a/src/components/Combobox/ComboboxWrapper.tsx
+++ b/src/components/Combobox/ComboboxWrapper.tsx
@@ -50,7 +50,7 @@ export const ComboboxWrapper = ({
       gap={6}
       {...getLabelProps({ htmlFor: id })}
     >
-      <Box display="flex" flexDirection="column">
+      <Box display="flex" flexDirection="column" width="100%">
         <Box
           as="span"
           className={classNames(spanRecipe({ typed, size, disabled, error }))}

--- a/src/components/RadioGroup/Group.css.ts
+++ b/src/components/RadioGroup/Group.css.ts
@@ -1,0 +1,45 @@
+import { RecipeVariants, recipe } from "@vanilla-extract/recipes";
+import { sprinkles } from "~/theme";
+
+export const fieldset = sprinkles({
+  padding: 0,
+  margin: 0,
+  borderWidth: 0,
+});
+
+export const groupLabelRecipe = recipe({
+  base: [
+    sprinkles({
+      padding: 0,
+      margin: 0,
+      color: "textNeutralSubdued",
+    }),
+  ],
+  variants: {
+    size: {
+      small: sprinkles({
+        typeSize: "captionSmall",
+      }),
+      medium: sprinkles({
+        typeSize: "captionMedium",
+      }),
+      large: sprinkles({
+        typeSize: "captionLarge",
+      }),
+    },
+    disabled: {
+      true: sprinkles({
+        color: "textNeutralDisabled",
+      }),
+    },
+    error: {
+      true: sprinkles({
+        color: "textCriticalSubdued",
+      }),
+    },
+  },
+  defaultVariants: {
+    size: "medium",
+  },
+});
+export type RadioGroupVariants = RecipeVariants<typeof groupLabelRecipe>;

--- a/src/components/RadioGroup/Group.tsx
+++ b/src/components/RadioGroup/Group.tsx
@@ -1,8 +1,10 @@
 import { Root } from "@radix-ui/react-radio-group";
 import { forwardRef, ReactNode } from "react";
 
+import { classNames } from "~/utils";
 import { Box, PropsWithBox } from "../Box";
 import { DataAttributes } from "../types";
+import { fieldset, groupLabelRecipe, RadioGroupVariants } from "./Group.css";
 
 export type RadioGroupRootProps = PropsWithBox<
   {
@@ -10,13 +12,43 @@ export type RadioGroupRootProps = PropsWithBox<
     className?: string;
     value?: string;
     onValueChange?: (value: string) => void;
+    label?: ReactNode;
   } & DataAttributes
->;
+> &
+  RadioGroupVariants;
 
 export const RadioGroupRoot = forwardRef<HTMLDivElement, RadioGroupRootProps>(
-  ({ children, className, value, onValueChange, ...rest }, ref) => (
+  (
+    {
+      children,
+      className,
+      value,
+      label,
+      onValueChange,
+      size,
+      disabled = false,
+      error = false,
+      ...rest
+    },
+    ref
+  ) => (
     <Root asChild value={value} onValueChange={onValueChange}>
-      <Box {...rest} className={className} ref={ref}>
+      <Box
+        {...rest}
+        className={classNames(fieldset, className)}
+        ref={ref}
+        as="fieldset"
+      >
+        {label && (
+          <legend
+            className={classNames(
+              groupLabelRecipe({ disabled, error, size }),
+              className
+            )}
+          >
+            {label}
+          </legend>
+        )}
         {children}
       </Box>
     </Root>

--- a/src/components/RadioGroup/RadioGroup.stories.tsx
+++ b/src/components/RadioGroup/RadioGroup.stories.tsx
@@ -1,3 +1,4 @@
+// eslint-disable react/jsx-key
 import { Meta, StoryObj } from "@storybook/react";
 import { Text } from "../Text";
 import { RadioGroup } from "./index";
@@ -6,6 +7,24 @@ const meta: Meta<typeof RadioGroup> = {
   title: "Components / RadioGroup",
   tags: ["autodocs"],
   component: RadioGroup,
+  argTypes: {
+    size: {
+      type: {
+        name: "enum",
+        value: ["small", "medium", "large"],
+      },
+    },
+  },
+  render: (args) => (
+    <RadioGroup {...args}>
+      <RadioGroup.Item value="default-unchecked" id="default-unchecked">
+        <Text size={args.size}>Unchecked</Text>
+      </RadioGroup.Item>
+      <RadioGroup.Item value="default-checked" id="default-checked">
+        <Text size={args.size}>Checked</Text>
+      </RadioGroup.Item>
+    </RadioGroup>
+  ),
 };
 
 export default meta;
@@ -13,52 +32,24 @@ type Story = StoryObj<typeof RadioGroup>;
 
 export const Primary: Story = {
   args: {
+    label: "Should it be checked?",
     value: "default-checked",
-    children: [
-      // eslint-disable-next-line react/jsx-key
-      <RadioGroup.Item value="default-unchecked" id="default-unchecked">
-        <Text>Unchecked</Text>
-      </RadioGroup.Item>,
-      // eslint-disable-next-line react/jsx-key
-      <RadioGroup.Item value="default-checked" id="default-checked">
-        <Text>Checked</Text>
-      </RadioGroup.Item>,
-    ],
+    size: "medium",
   },
 };
 
 export const Errored: Story = {
   args: {
+    label: "Should it be checked?",
     value: "default-checked",
-    children: [
-      // eslint-disable-next-line react/jsx-key
-      <RadioGroup.Item value="default-unchecked" id="default-unchecked" error>
-        <Text>Unchecked</Text>
-      </RadioGroup.Item>,
-      // eslint-disable-next-line react/jsx-key
-      <RadioGroup.Item value="default-checked" id="default-checked" error>
-        <Text>Checked</Text>
-      </RadioGroup.Item>,
-    ],
+    error: true,
   },
 };
 
 export const Disabled: Story = {
   args: {
+    label: "Should it be checked?",
     value: "default-checked",
-    children: [
-      // eslint-disable-next-line react/jsx-key
-      <RadioGroup.Item
-        value="default-unchecked"
-        id="default-unchecked"
-        disabled
-      >
-        <Text>Unchecked</Text>
-      </RadioGroup.Item>,
-      // eslint-disable-next-line react/jsx-key
-      <RadioGroup.Item value="default-checked" id="default-checked" disabled>
-        <Text>Checked</Text>
-      </RadioGroup.Item>,
-    ],
+    disabled: true,
   },
 };


### PR DESCRIPTION
Add fieldset and label elements to the radio group component. Allow specifying optional `label` prop.

### Screenshots

<img width="171" alt="Screenshot 2023-05-15 at 14 36 14" src="https://github.com/saleor/macaw-ui/assets/1338731/5fa7d7ca-3a8e-480f-bb7d-847127b126a9">

### Pull Request Checklist

- [ ] ~~New components are exported from `./src/components/index.ts`.~~
- [x] Storybook story is created and documentation properly generated.
