### PR TITLE
Make import of external font styles optional

### DIFF
--- a/src/theme/Baseline.tsx
+++ b/src/theme/Baseline.tsx
@@ -4,71 +4,78 @@ import React from "react";
 
 import { makeStyles } from "./styles";
 
-const useStyles = makeStyles(
-  (theme) => ({
-    "@global": {
-      "@import": "url('https://rsms.me/inter/inter.css')",
-      // Putting them here, because MUI doesn't let putting own keys in
-      // `overrides` objects
-      "@keyframes hoverControlStart": {
-        from: {
-          transform: "scale(1)",
-        },
-        to: {
-          transform: "scale(1.4)",
-        },
-      },
-      "@keyframes hoverControl": {
-        from: {
-          transform: "scale(1.4)",
-        },
-        to: {
-          transform: "scale(1.6)",
-        },
-      },
+type BaselineProps = {
+  importFontStyle: boolean;
+};
 
-      "@keyframes hoverSwitchStart": {
-        from: {
-          boxShadow: `0 0 0 0 ${theme.palette.saleor.active[5]}`,
+const useStyles = (props: BaselineProps) =>
+  makeStyles(
+    (theme) => ({
+      "@global": {
+        ...(props.importFontStyle && {
+          "@import": "url('https://rsms.me/inter/inter.css')",
+        }),
+        // Putting them here, because MUI doesn't let putting own keys in
+        // `overrides` objects
+        "@keyframes hoverControlStart": {
+          from: {
+            transform: "scale(1)",
+          },
+          to: {
+            transform: "scale(1.4)",
+          },
         },
-        to: {
-          boxShadow: `0 0 0 3px ${theme.palette.saleor.active[5]}`,
+        "@keyframes hoverControl": {
+          from: {
+            transform: "scale(1.4)",
+          },
+          to: {
+            transform: "scale(1.6)",
+          },
         },
-      },
-      "@keyframes hoverSwitch": {
-        from: {
-          boxShadow: `0 0 0 3px ${theme.palette.saleor.active[5]}`,
-        },
-        to: {
-          boxShadow: `0 0 0 5px ${theme.palette.saleor.active[5]}`,
-        },
-      },
 
-      ":root": {
-        "--background-paper": theme.palette.background.paper,
-        "--background-default": theme.palette.background.default,
-        colorScheme: theme.palette.type
-      },
+        "@keyframes hoverSwitchStart": {
+          from: {
+            boxShadow: `0 0 0 0 ${theme.palette.saleor.active[5]}`,
+          },
+          to: {
+            boxShadow: `0 0 0 3px ${theme.palette.saleor.active[5]}`,
+          },
+        },
+        "@keyframes hoverSwitch": {
+          from: {
+            boxShadow: `0 0 0 3px ${theme.palette.saleor.active[5]}`,
+          },
+          to: {
+            boxShadow: `0 0 0 5px ${theme.palette.saleor.active[5]}`,
+          },
+        },
 
-      // For some reason @import clause must be put on top
-      // eslint-disable-next-line sort-keys
-      "::selection": {
-        background: alpha(theme.palette.primary.main, 0.2),
-      },
-      html: {
-        fontSize: "58.4%",
-      },
-      a: {
-        color: "inherit",
-        textDecoration: "none",
-      },
-    },
-  }),
-  { name: "Baseline" }
-);
+        ":root": {
+          "--background-paper": theme.palette.background.paper,
+          "--background-default": theme.palette.background.default,
+          colorScheme: theme.palette.type,
+        },
 
-export const Baseline: React.FC = () => {
-  useStyles();
+        // For some reason @import clause must be put on top
+        // eslint-disable-next-line sort-keys
+        "::selection": {
+          background: alpha(theme.palette.primary.main, 0.2),
+        },
+        html: {
+          fontSize: "58.4%",
+        },
+        a: {
+          color: "inherit",
+          textDecoration: "none",
+        },
+      },
+    }),
+    { name: "Baseline" }
+  );
+
+export const Baseline: React.FC<BaselineProps> = (props) => {
+  useStyles(props);
 
   return <CssBaseline />;
 };

--- a/src/theme/ThemeProvider.tsx
+++ b/src/theme/ThemeProvider.tsx
@@ -34,6 +34,10 @@ export interface ThemeProviderProps {
    * Enables server side rendering.
    */
   ssr?: boolean;
+  /**
+   * Enables importing font style from external source.
+   */
+  importFontStyle?: boolean;
 }
 export const ThemeProvider: React.FC<ThemeProviderProps> = ({
   children,
@@ -41,6 +45,7 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({
   palettes = {},
   overrides = {},
   ssr = false,
+  importFontStyle = true,
 }) => {
   const { value: themeTypeName, setValue: setThemeType } = useLocalStorage(
     localStorageKeys.theme,
@@ -79,7 +84,7 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({
       <MuiThemeProvider theme={theme}>
         <ActionBarProvider>
           <BacklinkProvider>
-            <Baseline />
+            <Baseline importFontStyle={importFontStyle} />
             {children}
           </BacklinkProvider>
         </ActionBarProvider>


### PR DESCRIPTION
I want to merge this change because it makes import of external font styles from `rsms.me` optional. It causes CSP errors. 

This PR closes #...

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

- [ ] New components are exported from `./src/components/index.ts`.
- [ ] Storybook story is created and documentation properly generated.
