### PR TITLE
fix: add portals to combobox, select & multiselect with overflow

### DIFF
--- a/src/components/BaseSelect/BaseSelect.css.ts
+++ b/src/components/BaseSelect/BaseSelect.css.ts
@@ -1,6 +1,6 @@
 import { createVar, style } from "@vanilla-extract/css";
-import { recipe } from "@vanilla-extract/recipes";
 import { calc } from "@vanilla-extract/css-utils";
+import { recipe } from "@vanilla-extract/recipes";
 
 import { sprinkles, vars } from "~/theme";
 
@@ -50,15 +50,15 @@ export const listWrapperRecipe = recipe({
 
 export const listStyle = style([
   sprinkles({
-    position: "absolute",
+    // position: "absolute",
     backgroundColor: "surfaceNeutralPlain",
     boxShadow: "overlay",
     borderColor: "neutralHighlight",
     width: "100%",
     padding: 3,
     marginTop: 3,
-    left: 0,
-    zIndex: "3",
+    // left: 0,
+    // zIndex: "3",
   }),
   {
     borderRadius: calc.add(listItemBorderRadius, spaceBetweenListItemAndBorder),

--- a/src/components/BaseSelect/BaseSelect.css.ts
+++ b/src/components/BaseSelect/BaseSelect.css.ts
@@ -50,15 +50,14 @@ export const listWrapperRecipe = recipe({
 
 export const listStyle = style([
   sprinkles({
-    // position: "absolute",
     backgroundColor: "surfaceNeutralPlain",
     boxShadow: "overlay",
     borderColor: "neutralHighlight",
     width: "100%",
     padding: 3,
     marginTop: 3,
-    // left: 0,
-    // zIndex: "3",
+    maxHeight: "s52",
+    overflowY: "auto",
   }),
   {
     borderRadius: calc.add(listItemBorderRadius, spaceBetweenListItemAndBorder),

--- a/src/components/Combobox/Combobox.tsx
+++ b/src/components/Combobox/Combobox.tsx
@@ -1,17 +1,18 @@
-import { forwardRef, InputHTMLAttributes, ReactNode } from "react";
+import { Root as Portal } from "@radix-ui/react-portal";
+import { forwardRef, InputHTMLAttributes, ReactNode, useRef } from "react";
 
 import { classNames } from "~/utils";
 
-import {
-  Option,
-  ChangeHandler,
-  useComboboxEvents,
-  InputValue,
-} from "./useComboboxEvents";
 import { ComboboxWrapper } from "./ComboboxWrapper";
-import { List, Text, Box, PropsWithBox } from "..";
+import {
+  ChangeHandler,
+  InputValue,
+  Option,
+  useComboboxEvents,
+} from "./useComboboxEvents";
+import { Box, List, PropsWithBox, Text } from "..";
 import { helperTextRecipe, inputRecipe, InputVariants } from "../BaseInput";
-import { listStyle, listItemStyle, listWrapperRecipe } from "../BaseSelect";
+import { listItemStyle, listStyle, listWrapperRecipe } from "../BaseSelect";
 
 export type ComboboxProps = PropsWithBox<
   Omit<
@@ -67,8 +68,10 @@ export const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(
       itemsToSelect,
     } = useComboboxEvents(value, options, onChange);
 
+    const containerRef = useRef<HTMLDivElement>(null);
+
     return (
-      <Box display="flex" flexDirection="column">
+      <Box display="flex" flexDirection="column" ref={containerRef}>
         <ComboboxWrapper
           id={id}
           typed={typed}
@@ -95,28 +98,35 @@ export const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(
           />
         </ComboboxWrapper>
 
-        <Box
-          position="relative"
-          display={isOpen && itemsToSelect.length > 0 ? "block" : "none"}
-          className={listWrapperRecipe({ size })}
-        >
-          <List as="ul" className={listStyle} {...getMenuProps()}>
-            {isOpen &&
-              itemsToSelect?.map((item, index) => (
-                <List.Item
-                  key={`${id}-${item}-${index}`}
-                  className={listItemStyle}
-                  {...getItemProps({
-                    item,
-                    index,
-                  })}
-                  active={highlightedIndex === index}
-                >
-                  <Text size={size}>{item.label}</Text>
-                </List.Item>
-              ))}
-          </List>
-        </Box>
+        <Portal asChild container={containerRef.current}>
+          <Box
+            position="relative"
+            display={isOpen && itemsToSelect.length > 0 ? "block" : "none"}
+            className={listWrapperRecipe({ size })}
+          >
+            <List
+              as="ul"
+              className={listStyle}
+              // suppress error because of rendering list in portal
+              {...getMenuProps({}, { suppressRefError: true })}
+            >
+              {isOpen &&
+                itemsToSelect?.map((item, index) => (
+                  <List.Item
+                    key={`${id}-${item}-${index}`}
+                    className={listItemStyle}
+                    {...getItemProps({
+                      item,
+                      index,
+                    })}
+                    active={highlightedIndex === index}
+                  >
+                    <Text size={size}>{item.label}</Text>
+                  </List.Item>
+                ))}
+            </List>
+          </Box>
+        </Portal>
 
         {helperText && (
           <Box className={helperTextRecipe({ size })}>

--- a/src/components/Multiselect/Multiselect.stories.tsx
+++ b/src/components/Multiselect/Multiselect.stories.tsx
@@ -12,6 +12,10 @@ const options = [
   { value: "Blue", label: "Blue" },
   { value: "Orange", label: "Orange" },
   { value: "Purple", label: "Purple" },
+  { value: "White", label: "White" },
+  { value: "Yellow", label: "Yellow" },
+  { value: "Pink", label: "Pink" },
+  { value: "Brown", label: "Brown" },
 ];
 
 const meta: Meta<typeof Multiselect> = {

--- a/src/components/Multiselect/Multiselect.tsx
+++ b/src/components/Multiselect/Multiselect.tsx
@@ -1,9 +1,6 @@
-import * as Portal from "@radix-ui/react-portal";
+import { Root as Portal } from "@radix-ui/react-portal";
 import { forwardRef, InputHTMLAttributes, ReactNode, useRef } from "react";
 
-import { Box, List, PropsWithBox, Text } from "..";
-import { helperTextRecipe, InputVariants } from "../BaseInput";
-import { listItemStyle, listStyle, listWrapperRecipe } from "../BaseSelect";
 import { MultiselectWrapper } from "./MultiselectWrapper";
 import {
   ChangeHandler,
@@ -11,6 +8,9 @@ import {
   RenderEndAdornmentType,
   useMultiselectEvents,
 } from "./useMultiselectEvents";
+import { Box, List, PropsWithBox, Text } from "..";
+import { helperTextRecipe, InputVariants } from "../BaseInput";
+import { listItemStyle, listStyle, listWrapperRecipe } from "../BaseSelect";
 
 import { multiselectInputRecipe } from "./Multiselect.css";
 
@@ -154,7 +154,7 @@ export const Multiselect = forwardRef<HTMLInputElement, MultiselectProps>(
           />
         </MultiselectWrapper>
 
-        <Portal.Root asChild container={containerRef.current}>
+        <Portal asChild container={containerRef.current}>
           <Box
             display={isOpen && hasItemsToSelect ? "block" : "none"}
             className={listWrapperRecipe({ size })}
@@ -162,9 +162,8 @@ export const Multiselect = forwardRef<HTMLInputElement, MultiselectProps>(
             <List
               as="ul"
               className={listStyle}
-              {...getMenuProps()}
-              __maxHeight="200px"
-              overflow="auto"
+              // suppress error because of rendering list in portal
+              {...getMenuProps({}, { suppressRefError: true })}
             >
               {isOpen &&
                 itemsToSelect?.map((item, index) => (
@@ -182,7 +181,7 @@ export const Multiselect = forwardRef<HTMLInputElement, MultiselectProps>(
                 ))}
             </List>
           </Box>
-        </Portal.Root>
+        </Portal>
 
         {helperText && (
           <Box className={helperTextRecipe({ size })}>

--- a/src/components/Multiselect/Multiselect.tsx
+++ b/src/components/Multiselect/Multiselect.tsx
@@ -1,15 +1,16 @@
-import { forwardRef, InputHTMLAttributes, ReactNode } from "react";
+import * as Portal from "@radix-ui/react-portal";
+import { forwardRef, InputHTMLAttributes, ReactNode, useRef } from "react";
 
-import {
-  Option,
-  ChangeHandler,
-  useMultiselectEvents,
-  RenderEndAdornmentType,
-} from "./useMultiselectEvents";
-import { MultiselectWrapper } from "./MultiselectWrapper";
-import { listItemStyle, listStyle, listWrapperRecipe } from "../BaseSelect";
-import { List, Text, Box, PropsWithBox } from "..";
+import { Box, List, PropsWithBox, Text } from "..";
 import { helperTextRecipe, InputVariants } from "../BaseInput";
+import { listItemStyle, listStyle, listWrapperRecipe } from "../BaseSelect";
+import { MultiselectWrapper } from "./MultiselectWrapper";
+import {
+  ChangeHandler,
+  Option,
+  RenderEndAdornmentType,
+  useMultiselectEvents,
+} from "./useMultiselectEvents";
 
 import { multiselectInputRecipe } from "./Multiselect.css";
 
@@ -74,8 +75,10 @@ export const Multiselect = forwardRef<HTMLInputElement, MultiselectProps>(
       hasItemsToSelect,
     } = useMultiselectEvents(value, options, onChange, disabled);
 
+    const containerRef = useRef<HTMLDivElement>(null);
+
     return (
-      <Box display="flex" flexDirection="column" gap={3}>
+      <Box display="flex" flexDirection="column" gap={3} ref={containerRef}>
         <MultiselectWrapper
           id={id}
           typed={typed}
@@ -151,28 +154,35 @@ export const Multiselect = forwardRef<HTMLInputElement, MultiselectProps>(
           />
         </MultiselectWrapper>
 
-        <Box
-          position="relative"
-          display={isOpen && hasItemsToSelect ? "block" : "none"}
-          className={listWrapperRecipe({ size })}
-        >
-          <List as="ul" className={listStyle} {...getMenuProps()}>
-            {isOpen &&
-              itemsToSelect?.map((item, index) => (
-                <List.Item
-                  key={`to-select-${id}-${item}-${index}`}
-                  className={listItemStyle}
-                  active={highlightedIndex === index}
-                  {...getItemProps({
-                    item,
-                    index,
-                  })}
-                >
-                  <Text size={size}>{item.label}</Text>
-                </List.Item>
-              ))}
-          </List>
-        </Box>
+        <Portal.Root asChild container={containerRef.current}>
+          <Box
+            display={isOpen && hasItemsToSelect ? "block" : "none"}
+            className={listWrapperRecipe({ size })}
+          >
+            <List
+              as="ul"
+              className={listStyle}
+              {...getMenuProps()}
+              __maxHeight="200px"
+              overflow="auto"
+            >
+              {isOpen &&
+                itemsToSelect?.map((item, index) => (
+                  <List.Item
+                    key={`to-select-${id}-${item}-${index}`}
+                    className={listItemStyle}
+                    active={highlightedIndex === index}
+                    {...getItemProps({
+                      item,
+                      index,
+                    })}
+                  >
+                    <Text size={size}>{item.label}</Text>
+                  </List.Item>
+                ))}
+            </List>
+          </Box>
+        </Portal.Root>
 
         {helperText && (
           <Box className={helperTextRecipe({ size })}>

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -1,10 +1,17 @@
-import { forwardRef, InputHTMLAttributes, ReactNode, FocusEvent } from "react";
+import { Root as Portal } from "@radix-ui/react-portal";
+import {
+  FocusEvent,
+  InputHTMLAttributes,
+  ReactNode,
+  forwardRef,
+  useRef,
+} from "react";
 
-import { Option, ChangeHandler, useSelectEvents } from "./useSelectEvents";
 import { SelectWrapper } from "./SelectWrapper";
-import { List, Text, Box, PropsWithBox } from "..";
-import { helperTextRecipe, InputVariants } from "../BaseInput";
-import { listStyle, listItemStyle, listWrapperRecipe } from "../BaseSelect";
+import { ChangeHandler, Option, useSelectEvents } from "./useSelectEvents";
+import { Box, List, PropsWithBox, Text } from "..";
+import { InputVariants, helperTextRecipe } from "../BaseInput";
+import { listItemStyle, listStyle, listWrapperRecipe } from "../BaseSelect";
 
 export type SelectProps = PropsWithBox<
   Omit<
@@ -72,8 +79,10 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
       handlers,
     } = useSelectEvents(value, options, onChange);
 
+    const containerRef = useRef<HTMLDivElement>(null);
+
     return (
-      <Box display="flex" flexDirection="column">
+      <Box display="flex" flexDirection="column" ref={containerRef}>
         <SelectWrapper
           id={id}
           typed={typed}
@@ -105,28 +114,35 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
           </Box>
         </SelectWrapper>
 
-        <Box
-          position="relative"
-          display={isOpen ? "block" : "none"}
-          className={listWrapperRecipe({ size })}
-        >
-          <List as="ul" className={listStyle} {...getMenuProps()}>
-            {isOpen &&
-              options?.map((item, index) => (
-                <List.Item
-                  key={`${id}-${item}-${index}`}
-                  className={listItemStyle}
-                  {...getItemProps({
-                    item,
-                    index,
-                  })}
-                  active={highlightedIndex === index}
-                >
-                  <Text size={size}>{item.label}</Text>
-                </List.Item>
-              ))}
-          </List>
-        </Box>
+        <Portal asChild container={containerRef.current}>
+          <Box
+            position="relative"
+            display={isOpen ? "block" : "none"}
+            className={listWrapperRecipe({ size })}
+          >
+            <List
+              as="ul"
+              className={listStyle}
+              // suppress error because of rendering list in portal
+              {...getMenuProps({}, { suppressRefError: true })}
+            >
+              {isOpen &&
+                options?.map((item, index) => (
+                  <List.Item
+                    key={`${id}-${item}-${index}`}
+                    className={listItemStyle}
+                    {...getItemProps({
+                      item,
+                      index,
+                    })}
+                    active={highlightedIndex === index}
+                  >
+                    <Text size={size}>{item.label}</Text>
+                  </List.Item>
+                ))}
+            </List>
+          </Box>
+        </Portal>
 
         {helperText && (
           <Box marginTop={3} className={helperTextRecipe({ size })}>

--- a/src/theme/contract.css.ts
+++ b/src/theme/contract.css.ts
@@ -47,6 +47,13 @@ export const vars = createGlobalThemeContract(
       s16: null,
       s20: null,
       s24: null,
+      s28: null,
+      s32: null,
+      s36: null,
+      s40: null,
+      s44: null,
+      s48: null,
+      s52: null,
     },
     colors: {
       foreground: {

--- a/src/theme/sprinkles.css.ts
+++ b/src/theme/sprinkles.css.ts
@@ -122,7 +122,7 @@ const responsiveProperties = defineProperties({
     minHeight: ["auto", "100%", "0px"],
     minWidth: { ...vars.space, auto: "auto", "100%": "100%" },
     maxWidth: ["auto", "100%", "0px"],
-    maxHeight: ["auto", "100%", "0px"],
+    maxHeight: { ...vars.space, auto: "auto", "100%": "100%", "0px": "0px" },
     borderTopRightRadius: {
       ...vars.borderRadius,
       "50%": "50%",

--- a/src/theme/themes/common.ts
+++ b/src/theme/themes/common.ts
@@ -21,6 +21,13 @@ export const space = {
   s16: "64px",
   s20: "80px",
   s24: "96px",
+  s28: "112px",
+  s32: "128px",
+  s36: "144px",
+  s40: "160px",
+  s44: "176px",
+  s48: "192px",
+  s52: "208px",
 };
 
 // TODO: #438 remove legacy spacing


### PR DESCRIPTION
I want to merge this change because it adds `Portal` to combobox, select and multi select components. It also adds overflow to list of items to select in those components.


### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->
![CleanShot 2023-05-24 at 08 03 54@2x](https://github.com/saleor/macaw-ui/assets/9116238/f3776307-737a-483a-ac16-f2b1a36aca91)

### Pull Request Checklist

- [ ] New components are exported from `./src/components/index.ts`.
- [ ] Storybook story is created and documentation properly generated.
