### PR TITLE
fix: adjust components after migrating to the new scale

### DIFF
--- a/src/components/BaseSelect/BaseSelect.css.ts
+++ b/src/components/BaseSelect/BaseSelect.css.ts
@@ -70,7 +70,7 @@ export const listStyle = style([
 
 export const listItemStyle = style([
   sprinkles({
-    padding: 5,
+    padding: 2,
   }),
   {
     borderRadius: listItemBorderRadius,

--- a/src/components/Multiselect/Multiselect.tsx
+++ b/src/components/Multiselect/Multiselect.tsx
@@ -78,7 +78,7 @@ export const Multiselect = forwardRef<HTMLInputElement, MultiselectProps>(
     const containerRef = useRef<HTMLDivElement>(null);
 
     return (
-      <Box display="flex" flexDirection="column" gap={3} ref={containerRef}>
+      <Box display="flex" flexDirection="column" ref={containerRef}>
         <MultiselectWrapper
           id={id}
           typed={typed}

--- a/src/components/Popover/Popover.stories.tsx
+++ b/src/components/Popover/Popover.stories.tsx
@@ -1,7 +1,6 @@
 import { Meta, StoryObj } from "@storybook/react";
-import { Text } from "../Text";
-import { ConfigurationIcon } from "../Icons";
-import { Button } from "../Button";
+import { Box, Button, ConfigurationIcon, Text } from "..";
+
 import { Popover } from "./index";
 
 const meta: Meta<typeof Popover> = {
@@ -24,8 +23,10 @@ export const Primary: Story = {
       </Popover.Trigger>,
       // eslint-disable-next-line react/jsx-key
       <Popover.Content>
-        <Popover.Arrow />
-        <Text>Popover content.</Text>
+        <Box>
+          <Popover.Arrow />
+          <Text>Popover content.</Text>
+        </Box>
       </Popover.Content>,
     ],
   },

--- a/src/components/Text/Text.stories.tsx
+++ b/src/components/Text/Text.stories.tsx
@@ -10,7 +10,7 @@ const meta: Meta<typeof Text> = {
 export default meta;
 type Story = StoryObj<typeof Text>;
 
-export const Primary: Story = {
+export const Hero: Story = {
   args: {
     variant: "hero",
     children: "Some text",
@@ -19,49 +19,49 @@ export const Primary: Story = {
 
 export const Title: Story = {
   args: {
-    ...Primary.args,
+    ...Hero.args,
     variant: "title",
   },
 };
 
 export const Heading: Story = {
   args: {
-    ...Primary.args,
+    ...Hero.args,
     variant: "heading",
   },
 };
 
 export const BodyStrong: Story = {
   args: {
-    ...Primary.args,
+    ...Hero.args,
     variant: "bodyStrong",
   },
 };
 
 export const BodyEmp: Story = {
   args: {
-    ...Primary.args,
+    ...Hero.args,
     variant: "bodyEmp",
   },
 };
 
 export const Body: Story = {
   args: {
-    ...Primary.args,
+    ...Hero.args,
     variant: "body",
   },
 };
 
 export const Button: Story = {
   args: {
-    ...Primary.args,
+    ...Hero.args,
     variant: "button",
   },
 };
 
 export const Caption: Story = {
   args: {
-    ...Primary.args,
+    ...Hero.args,
     variant: "caption",
   },
 };


### PR DESCRIPTION
I want to merge this change because it fixes:
* wrong spacing in Multiselect, Combobox and Select component
* wrong gap in Mulitselect
* error when rendering Popover component
* Text story naming

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

| Before | After |
| ------- | ------- |
| ![CleanShot 2023-05-30 at 10 42 18@2x](https://github.com/saleor/macaw-ui/assets/9116238/d21e4b1b-a5a4-48d4-8fe8-4f2ec096d08f) | ![CleanShot 2023-05-30 at 10 41 41@2x](https://github.com/saleor/macaw-ui/assets/9116238/927a0682-075f-4009-ab4f-38c538bafd8e) |
  

### Pull Request Checklist

- [ ] New components are exported from `./src/components/index.ts`.
- [ ] Storybook story is created and documentation properly generated.
