### PR TITLE
fix: bring back position absolute for select list

### DIFF
--- a/src/components/BaseSelect/BaseSelect.css.ts
+++ b/src/components/BaseSelect/BaseSelect.css.ts
@@ -50,12 +50,12 @@ export const listWrapperRecipe = recipe({
 
 export const listStyle = style([
   sprinkles({
+    position: "absolute",
     backgroundColor: "surfaceNeutralPlain",
     boxShadow: "overlay",
     borderColor: "neutralHighlight",
     width: "100%",
     padding: 1,
-    marginTop: 1,
     left: 0,
     maxHeight: 52,
     overflowY: "auto",

--- a/src/components/Combobox/Combobox.stories.tsx
+++ b/src/components/Combobox/Combobox.stories.tsx
@@ -22,6 +22,14 @@ const meta: Meta<typeof Combobox> = {
     id: "combobox",
     size: "large",
   },
+  parameters: {
+    docs: {
+      story: {
+        inline: false,
+        iframeHeight: 300,
+      },
+    },
+  },
 };
 
 export default meta;

--- a/src/components/Combobox/Combobox.tsx
+++ b/src/components/Combobox/Combobox.tsx
@@ -68,10 +68,10 @@ export const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(
       itemsToSelect,
     } = useComboboxEvents(value, options, onChange);
 
-    const containerRef = useRef<HTMLDivElement>(null);
+    const containerRef = useRef<HTMLLabelElement>(null);
 
     return (
-      <Box display="flex" flexDirection="column" ref={containerRef}>
+      <Box display="flex" flexDirection="column">
         <ComboboxWrapper
           id={id}
           typed={typed}
@@ -97,6 +97,7 @@ export const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(
             })}
           />
         </ComboboxWrapper>
+        <Box ref={containerRef} />
 
         <Portal asChild container={containerRef.current}>
           <Box

--- a/src/components/Multiselect/Multiselect.stories.tsx
+++ b/src/components/Multiselect/Multiselect.stories.tsx
@@ -28,6 +28,14 @@ const meta: Meta<typeof Multiselect> = {
     id: "multiselect",
     size: "large",
   },
+  parameters: {
+    docs: {
+      story: {
+        inline: false,
+        iframeHeight: 300,
+      },
+    },
+  },
 };
 
 export default meta;

--- a/src/components/Multiselect/Multiselect.tsx
+++ b/src/components/Multiselect/Multiselect.tsx
@@ -78,7 +78,7 @@ export const Multiselect = forwardRef<HTMLInputElement, MultiselectProps>(
     const containerRef = useRef<HTMLDivElement>(null);
 
     return (
-      <Box display="flex" flexDirection="column" ref={containerRef}>
+      <Box display="flex" flexDirection="column">
         <MultiselectWrapper
           id={id}
           typed={typed}
@@ -154,8 +154,11 @@ export const Multiselect = forwardRef<HTMLInputElement, MultiselectProps>(
           />
         </MultiselectWrapper>
 
+        <Box ref={containerRef} />
+
         <Portal asChild container={containerRef.current}>
           <Box
+            position="relative"
             display={isOpen && hasItemsToSelect ? "block" : "none"}
             className={listWrapperRecipe({ size })}
           >

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -21,6 +21,14 @@ const meta: Meta<typeof Select> = {
     label: "Pick a color",
     size: "large",
   },
+  parameters: {
+    docs: {
+      story: {
+        inline: false,
+        iframeHeight: 300,
+      },
+    },
+  },
 };
 
 export default meta;

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -82,7 +82,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
     const containerRef = useRef<HTMLDivElement>(null);
 
     return (
-      <Box display="flex" flexDirection="column" ref={containerRef}>
+      <Box display="flex" flexDirection="column">
         <SelectWrapper
           id={id}
           typed={typed}
@@ -113,6 +113,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
             </Text>
           </Box>
         </SelectWrapper>
+        <Box ref={containerRef} />
 
         <Portal asChild container={containerRef.current}>
           <Box


### PR DESCRIPTION
I want to merge this change because it fixes two issues:
* list of items to select taking space on the UI
* broken UI when there is a helper text

This PR closes #...

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

| Before | After |
| ------- | ------- |
| ![CleanShot 2023-06-02 at 14 36 07@2x](https://github.com/saleor/macaw-ui/assets/9116238/674b7ab6-561a-442f-95e7-8ca0d6cfbd68) | ![CleanShot 2023-06-02 at 14 35 46@2x](https://github.com/saleor/macaw-ui/assets/9116238/b464c55e-0d76-4bce-804d-f401ff1172de) |
  

### Pull Request Checklist

- [ ] New components are exported from `./src/components/index.ts`.
- [ ] Storybook story is created and documentation properly generated.
