### PR TITLE
fix: muliselect missing input when empty values

### DIFF
--- a/src/components/Multiselect/Multiselect.tsx
+++ b/src/components/Multiselect/Multiselect.tsx
@@ -144,7 +144,6 @@ export const Multiselect = forwardRef<HTMLInputElement, MultiselectProps>(
             width={0}
             __flex={1}
             minWidth={7}
-            display={hasItemsToSelect ? "block" : "none"}
             {...getInputProps({
               id,
               ref,

--- a/src/components/Multiselect/useMultiselectEvents.tsx
+++ b/src/components/Multiselect/useMultiselectEvents.tsx
@@ -109,6 +109,8 @@ export const useMultiselectEvents = (
               ...selectedItems.map((i) => i.value),
               newSelectedItem.value,
             ]);
+          } else {
+            setInputValue("");
           }
           break;
 


### PR DESCRIPTION
I want to merge this change because it shows input in multi-select when no value is found.


### Screenshots



### Pull Request Checklist

- [ ] New components are exported from `./src/components/index.ts`.
- [ ] Storybook story is created and documentation properly generated.
