### PR TITLE
feat: hide input when all item selected in multiselect

### DIFF
--- a/src/components/Multiselect/Multiselect.tsx
+++ b/src/components/Multiselect/Multiselect.tsx
@@ -76,6 +76,7 @@ export const Multiselect = forwardRef<HTMLInputElement, MultiselectProps>(
     } = useMultiselectEvents(value, options, onChange, disabled);
 
     const containerRef = useRef<HTMLDivElement>(null);
+    const showInput = hasItemsToSelect; // && !onAutocomplete <- uncomment when autocomplete is implemented
 
     return (
       <Box display="flex" flexDirection="column">
@@ -144,6 +145,7 @@ export const Multiselect = forwardRef<HTMLInputElement, MultiselectProps>(
             width={0}
             __flex={1}
             minWidth={7}
+            visibility={showInput ? "visible" : "hidden"}
             {...getInputProps({
               id,
               ref,
@@ -163,6 +165,7 @@ export const Multiselect = forwardRef<HTMLInputElement, MultiselectProps>(
           >
             <List
               as="ul"
+              zIndex={3}
               className={listStyle}
               // suppress error because of rendering list in portal
               {...getMenuProps({}, { suppressRefError: true })}

--- a/src/theme/sprinkles.css.ts
+++ b/src/theme/sprinkles.css.ts
@@ -168,6 +168,7 @@ const responsiveProperties = defineProperties({
     opacity: ["0", "0.2", "0.4", "0.6", "0.8", "1"],
     fontWeight: vars.fontWeight,
     alignSelf: ["auto", "normal", "end", "center", "start"],
+    visibility: ["visible", "hidden"],
   },
   shorthands: {
     padding: ["paddingTop", "paddingBottom", "paddingLeft", "paddingRight"],


### PR DESCRIPTION
I want to merge this change because it fix showing input when there is not items to select

This PR closes #...

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

- [ ] New components are exported from `./src/components/index.ts`.
- [ ] Storybook story is created and documentation properly generated.
