### PR TITLE
feat: add data-macaw-ui-component attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,20 @@ import { Input } from "@saleor/macaw-ui/next";
 />;
 ```
 
+### Usage with Sentry
+
+Add following configuration to `Sentry.Integrations.Breadcrumbs`:
+
+```js
+{
+  dom: {
+    serializeAttribute: ["macaw-ui-component"];
+  }
+}
+```
+
+Right now sentry will display MacawUI components names in breadcrumbs.
+
 ### Development
 
 To begin, you need to install dependencies:

--- a/src/components/Accordion/Item/Content.tsx
+++ b/src/components/Accordion/Item/Content.tsx
@@ -10,7 +10,9 @@ export type AccordionContentProps = PropsWithBox<{
 
 export const Content = ({ children, ...rest }: AccordionContentProps) => (
   <AccordionContent asChild className={content}>
-    <Box {...rest}>{children}</Box>
+    <Box {...rest} data-macaw-ui-component="Accordion.Content">
+      {children}
+    </Box>
   </AccordionContent>
 );
 

--- a/src/components/Accordion/Item/Item.tsx
+++ b/src/components/Accordion/Item/Item.tsx
@@ -13,7 +13,9 @@ export type AccordionItemProps = PropsWithBox<{
 export const Item = ({ children, value, ...rest }: AccordionItemProps) => {
   return (
     <AccordionItem value={value} className={trigger} asChild>
-      <Box {...rest}>{children}</Box>
+      <Box {...rest} data-macaw-ui-component="Accordion.Item">
+        {children}
+      </Box>
     </AccordionItem>
   );
 };

--- a/src/components/Accordion/Item/Trigger.tsx
+++ b/src/components/Accordion/Item/Trigger.tsx
@@ -31,6 +31,7 @@ export const Trigger = ({
         cursor={disabled ? "not-allowed" : "pointer"}
         disabled={disabled}
         {...rest}
+        data-macaw-ui-component="Accordion.Trigger"
       >
         {children}
       </Box>

--- a/src/components/Accordion/Item/TriggerButton.tsx
+++ b/src/components/Accordion/Item/TriggerButton.tsx
@@ -15,6 +15,7 @@ export const TriggerButton = ({ dataTestId, disabled }: TriggerButtonProps) => {
       type="button"
       data-test-id={dataTestId}
       disabled={disabled}
+      data-macaw-ui-component="Accordion.TriggerButton"
     />
   );
 };

--- a/src/components/Accordion/Root.tsx
+++ b/src/components/Accordion/Root.tsx
@@ -19,7 +19,7 @@ export const Root = forwardRef<HTMLElement, AccordionRootProps>(
       onValueChange={onValueChange}
       asChild
     >
-      <Box {...rest} ref={ref}>
+      <Box {...rest} ref={ref} data-macaw-ui-component="Accordion">
         {children}
       </Box>
     </AccordionRoot>

--- a/src/components/Avatar/Store/Store.tsx
+++ b/src/components/Avatar/Store/Store.tsx
@@ -24,6 +24,7 @@ export const Store = (props: StoreAvatarProps) => {
         src={src}
         alt="Store avatar image"
         className={classNames(storeAvatar({ size, scheme }), className)}
+        data-macaw-ui-component="Avatar.Store"
         {...rest}
       />
     );
@@ -33,6 +34,7 @@ export const Store = (props: StoreAvatarProps) => {
   return (
     <Box
       className={classNames(storeAvatar({ size, scheme }), className)}
+      data-macaw-ui-component="Avatar.Store"
       {...rest}
     >
       <Text variant="bodyEmp" size={size} color="inherit">

--- a/src/components/Avatar/User/User.tsx
+++ b/src/components/Avatar/User/User.tsx
@@ -24,6 +24,7 @@ export const User = (props: UserAvatarProps) => {
         src={src}
         alt="User avatar image"
         className={classNames(userAvatar({ size, scheme }), className)}
+        data-macaw-ui-component="Avatar.User"
         {...rest}
       />
     );
@@ -33,6 +34,7 @@ export const User = (props: UserAvatarProps) => {
   return (
     <Box
       className={classNames(userAvatar({ size, scheme }), className)}
+      data-macaw-ui-component="Avatar.User"
       {...rest}
     >
       <Text variant="bodyEmp" size={size} color="textNeutralContrasted">

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -45,6 +45,7 @@ export const Button = forwardRef<HTMLElement, ButtonProps>(
         disabled={disabled}
         ref={ref}
         type={type}
+        data-macaw-ui-component="Button"
         {...props}
       >
         {icon}

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -47,6 +47,7 @@ export const Checkbox = forwardRef<HTMLButtonElement, CheckboxProps>(
         position="relative"
         cursor={disabled ? "not-allowed" : "pointer"}
         {...props}
+        data-macaw-ui-component="Checkbox"
       >
         <RadixCheckbox
           ref={ref}

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -22,6 +22,7 @@ export const Chip = forwardRef<HTMLDivElement, ChipProps>(
           className
         )}
         ref={ref}
+        data-macaw-ui-component="Chip"
         {...props}
       >
         {children}

--- a/src/components/Combobox/ComboboxWrapper.tsx
+++ b/src/components/Combobox/ComboboxWrapper.tsx
@@ -48,6 +48,7 @@ export const ComboboxWrapper = ({
       disabled={disabled}
       flexWrap="nowrap"
       gap={3}
+      data-macaw-ui-component="Combobox"
       {...getLabelProps({ htmlFor: id })}
     >
       <Box display="flex" flexDirection="column" width="100%">

--- a/src/components/Divider/Divider.tsx
+++ b/src/components/Divider/Divider.tsx
@@ -15,6 +15,7 @@ export const Divider = forwardRef<HTMLHRElement, DividerProps>(
       borderWidth={0}
       width="100%"
       height="px"
+      data-macaw-ui-component="Divider"
       {...rest}
     />
   )

--- a/src/components/Drawer/Content.tsx
+++ b/src/components/Drawer/Content.tsx
@@ -30,6 +30,7 @@ export const Content = ({ children, ...rest }: DrawerContentProps) => {
           borderBottomRightRadius={3}
           position="fixed"
           paddingTop={7}
+          data-macaw-ui-component="Drawer.Content"
           {...rest}
         >
           {children}

--- a/src/components/Drawer/Root.tsx
+++ b/src/components/Drawer/Root.tsx
@@ -5,7 +5,7 @@ export type DrawerRootProps = {
 };
 
 export const Root = ({ children }: DrawerRootProps) => {
-  return <DialogRoot>{children}</DialogRoot>;
+  return <DialogRoot data-macaw-ui-component="Drawer">{children}</DialogRoot>;
 };
 
 Root.displayName = "Drawer";

--- a/src/components/Drawer/Trigger.tsx
+++ b/src/components/Drawer/Trigger.tsx
@@ -5,7 +5,11 @@ export type DrawerTriggerProps = {
 };
 
 export const Trigger = ({ children }: DrawerTriggerProps) => {
-  return <DialogTrigger asChild>{children}</DialogTrigger>;
+  return (
+    <DialogTrigger asChild data-macaw-ui-component="Drawer.Trigger">
+      {children}
+    </DialogTrigger>
+  );
 };
 
 Trigger.displayName = "Drawer.Trigger";

--- a/src/components/Dropdown/Content.tsx
+++ b/src/components/Dropdown/Content.tsx
@@ -16,7 +16,12 @@ export type DropdownContentProps = {
 export const Content = ({ children, ...rest }: DropdownContentProps) => {
   return (
     <DropdownMenuPortal>
-      <DropdownMenuContent asChild className={content} {...rest}>
+      <DropdownMenuContent
+        asChild
+        className={content}
+        data-macaw-ui-component="Dropdown.Content"
+        {...rest}
+      >
         {children}
       </DropdownMenuContent>
     </DropdownMenuPortal>

--- a/src/components/Dropdown/Item.tsx
+++ b/src/components/Dropdown/Item.tsx
@@ -9,7 +9,11 @@ type ItemProps = {
 
 export const Item = ({ children }: ItemProps) => {
   return (
-    <DropdownMenuItem asChild className={focusVisible}>
+    <DropdownMenuItem
+      asChild
+      className={focusVisible}
+      data-macaw-ui-component="Dropdown.Item"
+    >
       {children}
     </DropdownMenuItem>
   );

--- a/src/components/Dropdown/Root.tsx
+++ b/src/components/Dropdown/Root.tsx
@@ -13,7 +13,11 @@ export const DropdownRoot = ({
   open,
 }: DropdownRootProps) => {
   return (
-    <DropdownMenuRoot open={open} onOpenChange={onOpenChange}>
+    <DropdownMenuRoot
+      open={open}
+      onOpenChange={onOpenChange}
+      data-macaw-ui-component="Dropdown"
+    >
       {children}
     </DropdownMenuRoot>
   );

--- a/src/components/Dropdown/Trigger.tsx
+++ b/src/components/Dropdown/Trigger.tsx
@@ -6,7 +6,11 @@ export type DropdownTriggerProps = {
 };
 
 export const Trigger = ({ children }: DropdownTriggerProps) => {
-  return <DropdownMenuTrigger asChild>{children}</DropdownMenuTrigger>;
+  return (
+    <DropdownMenuTrigger asChild data-macaw-ui-component="Dropdown.Trigger">
+      {children}
+    </DropdownMenuTrigger>
+  );
 };
 
 Trigger.displayName = "Dropdown.Trigger";

--- a/src/components/DropdownButton/DropdownButton.tsx
+++ b/src/components/DropdownButton/DropdownButton.tsx
@@ -34,6 +34,7 @@ export const DropdownButton = forwardRef<
         )}
         disabled={disabled}
         ref={ref}
+        data-macaw-ui-component="DropdownButton"
         {...props}
       >
         {children}

--- a/src/components/Icons/SVGWrapper/SVGWrapper.tsx
+++ b/src/components/Icons/SVGWrapper/SVGWrapper.tsx
@@ -28,6 +28,7 @@ export const SVGWrapper = forwardRef<SVGSVGElement, SVGWrapperProps>(
         viewBox={viewBox}
         fill="none"
         xmlns="http://www.w3.org/2000/svg"
+        data-macaw-ui-component="Icon"
         {...rest}
       >
         {children}

--- a/src/components/Input/InputWrapper.tsx
+++ b/src/components/Input/InputWrapper.tsx
@@ -70,6 +70,7 @@ export const InputWrapper = ({
       )}
       alignItems="center"
       gap={1}
+      data-macaw-ui-component="Input"
     >
       <Box display="flex" flexDirection="column" width="100%">
         <Box

--- a/src/components/List/Divider.tsx
+++ b/src/components/List/Divider.tsx
@@ -11,8 +11,10 @@ export type ListDividerProps = PropsWithBox<
 
 export const Divider = ({ children, ...rest }: ListDividerProps) => {
   return (
-    <Box as="li" {...rest}>
+    <Box as="li" {...rest} data-macaw-ui-component="List.Divider">
       {children}
     </Box>
   );
 };
+
+Divider.displayName = "List.Divider";

--- a/src/components/List/Item.tsx
+++ b/src/components/List/Item.tsx
@@ -30,6 +30,7 @@ export const Item = forwardRef<HTMLElement, ListItemProps>(
         onClick={onClick}
         className={className}
         ref={ref}
+        data-macaw-ui-component="List.Item"
         {...rest}
       >
         {children}

--- a/src/components/List/ItemGroup/Content.tsx
+++ b/src/components/List/ItemGroup/Content.tsx
@@ -2,7 +2,11 @@ import { AccordionContent } from "@radix-ui/react-accordion";
 import { ReactNode } from "react";
 
 export const Content = ({ children }: { children: ReactNode }) => {
-  return <AccordionContent asChild>{children}</AccordionContent>;
+  return (
+    <AccordionContent asChild data-macaw-ui-component="ListItem.Content">
+      {children}
+    </AccordionContent>
+  );
 };
 
 Content.displayName = "ListItem.Content";

--- a/src/components/List/ItemGroup/Root.tsx
+++ b/src/components/List/ItemGroup/Root.tsx
@@ -35,7 +35,7 @@ export const ItemGroupRoot = ({
       onValueChange={setValue}
     >
       <Provider value={{ triggerOpen: () => setValue(expandedValue) }}>
-        <List as={as} {...rest}>
+        <List as={as} {...rest} data-macaw-ui-component="ListItem">
           <AccordionItem value={expandedValue} className={trigger}>
             {children}
           </AccordionItem>

--- a/src/components/List/ItemGroup/Trigger.tsx
+++ b/src/components/List/ItemGroup/Trigger.tsx
@@ -23,7 +23,7 @@ export const Trigger = ({ children, size, ...rest }: ItemGroupTriggerProps) => {
 
   return (
     // Importing List.Item instead of Item fixes vite HMR
-    <List.Item {...rest}>
+    <List.Item data-macaw-ui-component="ItemGroup.Trigger" {...rest}>
       <Box width="100%" height="100%" onClick={triggerOpen}>
         {children}
       </Box>

--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -11,7 +11,14 @@ export type ListProps = PropsWithBox<{
 export const List = forwardRef<HTMLUListElement | HTMLUListElement, ListProps>(
   ({ children, as = "ul", className, ...rest }, ref) => {
     return (
-      <Box as={as} ref={ref} className={className} margin={0} {...rest}>
+      <Box
+        as={as}
+        ref={ref}
+        className={className}
+        margin={0}
+        data-macaw-ui-component="List"
+        {...rest}
+      >
         {children}
       </Box>
     );

--- a/src/components/Multiselect/MultiselectWrapper.tsx
+++ b/src/components/Multiselect/MultiselectWrapper.tsx
@@ -50,6 +50,7 @@ export const MultiselectWrapper = ({
       disabled={disabled}
       flexWrap="nowrap"
       gap={3}
+      data-macaw-ui-component="Multiselect"
       {...getLabelProps({ htmlFor: id })}
     >
       <Box display="flex" flexDirection="column" width="100%">

--- a/src/components/Popover/Anchor.tsx
+++ b/src/components/Popover/Anchor.tsx
@@ -5,7 +5,11 @@ export interface PopoverAnchorProps {
 }
 
 export const Anchor = ({ children }: PopoverAnchorProps) => {
-  return <RadixPopoverAnchor asChild>{children}</RadixPopoverAnchor>;
+  return (
+    <RadixPopoverAnchor asChild data-macaw-ui-component="Popover.Anchor">
+      {children}
+    </RadixPopoverAnchor>
+  );
 };
 
 Anchor.displayName = "Popover.Anchor";

--- a/src/components/Popover/Arrow.tsx
+++ b/src/components/Popover/Arrow.tsx
@@ -22,6 +22,7 @@ export const Arrow = ({
         viewBox="0 0 20 9"
         fill="none"
         xmlns="http://www.w3.org/2000/svg"
+        data-macaw-ui-component="Popover.Arrow"
       >
         <path
           d="M8.08579 7.08579L0.5 -0.5H18.5L10.9142 7.08579C10.1332 7.86683 8.86684 7.86684 8.08579 7.08579Z"

--- a/src/components/Popover/Content.tsx
+++ b/src/components/Popover/Content.tsx
@@ -25,6 +25,7 @@ export const Content = ({
       <RadixPopoverContent
         asChild
         className={classNames(popover, className)}
+        data-macaw-ui-component="Popover.Content"
         {...props}
       >
         {children}

--- a/src/components/Popover/Root.tsx
+++ b/src/components/Popover/Root.tsx
@@ -10,7 +10,11 @@ export type PopoverProps = {
 };
 
 export const PopoverRoot = ({ children, ...props }: PopoverProps) => {
-  return <RadixPopoverRoot {...props}>{children}</RadixPopoverRoot>;
+  return (
+    <RadixPopoverRoot {...props} data-macaw-ui-component="Popover">
+      {children}
+    </RadixPopoverRoot>
+  );
 };
 
 PopoverRoot.displayName = "Popover";

--- a/src/components/Popover/Trigger.tsx
+++ b/src/components/Popover/Trigger.tsx
@@ -5,7 +5,11 @@ export interface PopoverTriggerProps {
 }
 
 export const Trigger = ({ children }: PopoverTriggerProps) => {
-  return <RadixPopoverTrigger asChild>{children}</RadixPopoverTrigger>;
+  return (
+    <RadixPopoverTrigger asChild data-macaw-ui-component="Popover.Trigger">
+      {children}
+    </RadixPopoverTrigger>
+  );
 };
 
 Trigger.displayName = "Popover.Trigger";

--- a/src/components/RadioGroup/Group.tsx
+++ b/src/components/RadioGroup/Group.tsx
@@ -38,6 +38,7 @@ export const RadioGroupRoot = forwardRef<HTMLDivElement, RadioGroupRootProps>(
         className={classNames(fieldset, className)}
         ref={ref}
         as="fieldset"
+        data-macaw-ui-component="RadioGroup"
       >
         {label && (
           <legend

--- a/src/components/RadioGroup/Item.tsx
+++ b/src/components/RadioGroup/Item.tsx
@@ -26,6 +26,7 @@ export const RadioGroupItem = forwardRef<HTMLDivElement, RadioGroupItemProps>(
       {...rest}
       className={className}
       ref={ref}
+      data-macaw-ui-component="RadioGroup.Item"
     >
       <RadioGroup.Item
         className={item({ error, disabled })}

--- a/src/components/SearchInput/SearchInput.tsx
+++ b/src/components/SearchInput/SearchInput.tsx
@@ -20,7 +20,11 @@ export type SearchInputProps = PropsWithBox<
 export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
   ({ id, className, size, ...props }, ref) => {
     return (
-      <Box id={id} className={classNames(inputContainer({ size }), className)}>
+      <Box
+        id={id}
+        className={classNames(inputContainer({ size }), className)}
+        data-macaw-ui-component="SearchInput"
+      >
         <SearchIcon size="medium" className={searchIcon()} />
         <Box as="input" className={input()} ref={ref} type="text" {...props} />
       </Box>

--- a/src/components/Select/SelectWrapper.tsx
+++ b/src/components/Select/SelectWrapper.tsx
@@ -49,6 +49,7 @@ export const SelectWrapper = ({
       flexWrap="nowrap"
       gap={3}
       {...getToggleButtonProps({ disabled })}
+      data-macaw-ui-component="Select"
     >
       <Box display="flex" flexDirection="column">
         <Box

--- a/src/components/Switch/Switch.tsx
+++ b/src/components/Switch/Switch.tsx
@@ -23,6 +23,7 @@ export const SwitchRoot = forwardRef<HTMLDivElement, SwitchRootProps>(
         className={classNames(switchParent(), className)}
         ref={ref}
         {...rest}
+        data-macaw-ui-component="Switch"
       >
         {children}
       </Box>

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -34,6 +34,7 @@ export const Text = forwardRef<HTMLSpanElement, TextProps>(
         color={color}
         ref={ref}
         margin={0}
+        data-macaw-ui-component="Text"
         {...rest}
       >
         {children}

--- a/src/components/Toggle/Toggle.tsx
+++ b/src/components/Toggle/Toggle.tsx
@@ -21,6 +21,7 @@ export const Toggle = forwardRef<HTMLButtonElement, ToggleProps>(
         alignItems="center"
         gap={1.5}
         cursor={disabled ? "not-allowed" : "pointer"}
+        data-macaw-ui-component="Toggle"
       >
         <RadixToggle
           ref={ref}

--- a/src/components/Tooltip/Arrow.tsx
+++ b/src/components/Tooltip/Arrow.tsx
@@ -22,6 +22,7 @@ export const Arrow = ({
         viewBox="0 0 20 9"
         fill="none"
         xmlns="http://www.w3.org/2000/svg"
+        data-macaw-ui-component="Tooltip.Arrow"
       >
         <path
           fill={backgroundColor}

--- a/src/components/Tooltip/Content.tsx
+++ b/src/components/Tooltip/Content.tsx
@@ -29,6 +29,7 @@ export const Content = ({
         className={classNames(content, className)}
         sideOffset={sideOffset}
         avoidCollisions={avoidCollisions}
+        data-macaw-ui-component="Tooltip.Content"
         {...props}
       >
         {children}

--- a/src/components/Tooltip/ContentHeading.tsx
+++ b/src/components/Tooltip/ContentHeading.tsx
@@ -12,6 +12,7 @@ export const ContentHeading = ({ children }: TooltipContentHeadingProps) => {
       variant="caption"
       color="textNeutralSubdued"
       marginBottom={0.5}
+      data-macaw-ui-component="Tooltip.ContentHeading"
     >
       {children}
     </Text>

--- a/src/components/Tooltip/Root.tsx
+++ b/src/components/Tooltip/Root.tsx
@@ -20,7 +20,11 @@ export const TooltipRoot = ({
 }: TooltipProps) => {
   return (
     <RadixTooltipProvider>
-      <RadixTooltipRoot delayDuration={delayDuration} {...props}>
+      <RadixTooltipRoot
+        delayDuration={delayDuration}
+        {...props}
+        data-macaw-ui-component="Tooltip"
+      >
         {children}
       </RadixTooltipRoot>
     </RadixTooltipProvider>

--- a/src/components/Tooltip/Trigger.tsx
+++ b/src/components/Tooltip/Trigger.tsx
@@ -8,7 +8,11 @@ export interface TooltipTriggerProps {
 export const Trigger = forwardRef<HTMLButtonElement, TooltipTriggerProps>(
   ({ children }, ref) => {
     return (
-      <RadixTooltipTrigger asChild ref={ref}>
+      <RadixTooltipTrigger
+        asChild
+        ref={ref}
+        data-macaw-ui-component="Tooltip.Trigger"
+      >
         {children}
       </RadixTooltipTrigger>
     );


### PR DESCRIPTION
I want to merge this change because it adds the `data-macaw-ui-component` attribute to MacawUI components for better debugging.

This PR closes #464 

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

- [ ] New components are exported from `./src/components/index.ts`.
- [ ] Storybook story is created and documentation properly generated.
