### PR TITLE
fix: select regression

### DIFF
--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -1,18 +1,18 @@
 import { Root as Portal } from "@radix-ui/react-portal";
-import { InputHTMLAttributes, ReactNode, forwardRef } from "react";
+import { InputHTMLAttributes, ReactNode, forwardRef, useRef } from "react";
 
 import { Box, List, PropsWithBox, Text } from "..";
 import { HelperText, InputVariants } from "../BaseInput";
 import {
+  Option,
+  SingleChangeHandler,
   listItemStyle,
   listStyle,
   listWrapperRecipe,
-  Option,
-  SingleChangeHandler,
 } from "../BaseSelect";
 
-import { useSelect } from "./useSelect";
 import { SelectWrapper } from "./SelectWrapper";
+import { useSelect } from "./useSelect";
 
 export type SelectProps = PropsWithBox<
   Omit<
@@ -89,6 +89,8 @@ export const Select = forwardRef<HTMLElement, SelectProps>(
       onBlur,
     });
 
+    const containerRef = useRef<HTMLLabelElement>(null);
+
     return (
       <Box display="flex" flexDirection="column">
         <SelectWrapper
@@ -109,8 +111,9 @@ export const Select = forwardRef<HTMLElement, SelectProps>(
             </Text>
           </Box>
         </SelectWrapper>
+        <Box ref={containerRef} />
 
-        <Portal asChild>
+        <Portal asChild container={containerRef.current}>
           <Box
             position="relative"
             display={isOpen && hasItemsToSelect ? "block" : "none"}

--- a/src/components/Select/SelectWrapper.tsx
+++ b/src/components/Select/SelectWrapper.tsx
@@ -50,7 +50,7 @@ export const SelectWrapper = ({
       {...getToggleButtonProps()}
       data-macaw-ui-component="Select"
     >
-      <Box display="flex" flexDirection="column">
+      <Box display="flex" flexDirection="column" width="100%">
         <Box
           as="span"
           className={classNames(spanRecipe({ typed, size, disabled, error }))}


### PR DESCRIPTION
I want to merge this change because it fixes a regression from #459 



### Screenshots

| Before | After |
| ------- | ------- |
| ![CleanShot 2023-06-27 at 14 58 46@2x](https://github.com/saleor/macaw-ui/assets/9116238/46d559d7-b4a6-42db-b49c-9678d8542b6e) | ![CleanShot 2023-06-27 at 14 58 02@2x](https://github.com/saleor/macaw-ui/assets/9116238/a1b2475c-58ba-4559-9770-bffb05ede5bf) |
  
<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->


### Pull Request Checklist

- [ ] New components are exported from `./src/components/index.ts`.
- [ ] Storybook story is created and documentation properly generated.
