### PR TITLE
fix: package json fields used by package directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,18 +27,18 @@
   "packageManager": "pnpm@8.6.5",
   "exports": {
     "./next": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/macaw-ui.js",
-      "require": "./dist/macaw-ui.umd.cjs",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/macaw-ui.cjs"
     },
     "./next/style": {
       "import": "./dist/style.css",
       "require": "./dist/style.css"
     },
     ".": {
+      "types": "./legacy/dist/types/index.d.ts",
       "import": "./legacy/dist/esm/index.js",
-      "require": "./legacy/dist/cjs/index.js",
-      "types": "./legacy/dist/types/index.d.ts"
+      "require": "./legacy/dist/cjs/index.js"
     }
   },
   "keywords": [


### PR DESCRIPTION
I want to merge this change because this PR fixes errors from https://publint.dev/@saleor/macaw-ui@0.8.0-pre.101



### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->
![CleanShot 2023-06-29 at 08 25 33@2x](https://github.com/saleor/macaw-ui/assets/9116238/c71eca91-903b-41f6-a34e-6ca4ee22c6e0)

### Pull Request Checklist

- [ ] New components are exported from `./src/components/index.ts`.
- [ ] Storybook story is created and documentation properly generated.
