### PR TITLE
fix: wrong props with box type

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -31,6 +31,10 @@ export default {
         },
       },
       plugins: [require("@vanilla-extract/vite-plugin").vanillaExtractPlugin()],
+      build: {
+        ...config.build,
+        sourcemap: false,
+      },
     });
   },
 };

--- a/src/components/Box/Box.tsx
+++ b/src/components/Box/Box.tsx
@@ -9,7 +9,7 @@ export const Box = createBox({ atoms: sprinkles });
 
 export type PropsWithBox<T> = Omit<
   ComponentProps<typeof Box>,
-  //   omit size because it's a prop that's used by variants
-  keyof T | "size"
+  // omit size and ref as they are defined on components
+  keyof T | "size" | "ref"
 > &
   T;

--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -8,7 +8,7 @@ export type ListProps = PropsWithBox<{
   className?: string;
 }>;
 
-export const List = forwardRef<HTMLUListElement | HTMLLIElement, ListProps>(
+export const List = forwardRef<HTMLUListElement | HTMLOListElement, ListProps>(
   ({ children, as = "ul", className, ...rest }, ref) => {
     return (
       <Box

--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -8,7 +8,7 @@ export type ListProps = PropsWithBox<{
   className?: string;
 }>;
 
-export const List = forwardRef<HTMLUListElement | HTMLUListElement, ListProps>(
+export const List = forwardRef<HTMLUListElement | HTMLLIElement, ListProps>(
   ({ children, as = "ul", className, ...rest }, ref) => {
     return (
       <Box


### PR DESCRIPTION
I want to merge this change because it allows spreading component props on its component if there is a ref defined e.g:

```tsx
const props: ListProps = {};

<List {...props} />
```

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

- [ ] New components are exported from `./src/components/index.ts`.
- [ ] Storybook story is created and documentation properly generated.
