### PR TITLE
feat: export FilterEvent for experimental filters

### DIFF
--- a/src/components/ExperimentalFilters/index.ts
+++ b/src/components/ExperimentalFilters/index.ts
@@ -5,6 +5,7 @@ export type {
   AddRowButtonProps,
   ConfirmButtonProps,
 } from "./ExperimentalFilters";
+export type { FilterEvent } from "./useEvents";
 import {
   _ExperimentalFilters as Root,
   AddRowButton,

--- a/src/components/ExperimentalFilters/useEvents.tsx
+++ b/src/components/ExperimentalFilters/useEvents.tsx
@@ -2,30 +2,68 @@ import { useEffect } from "react";
 import { FilterEventEmitter } from "./EventEmitter";
 
 export interface FilterEvent extends Event {
-  detail?: {
-    type:
-      | "leftOperator.onChange"
-      | "leftOperator.onInputValueChange"
-      | "leftOperator.onFocus"
-      | "leftOperator.onBlur"
-      | "condition.onChange"
-      | "condition.onScrollEnd"
-      | "condition.onFocus"
-      | "condition.onBlur"
-      | "rightOperator.onChange"
-      | "rightOperator.onInputValueChange"
-      | "rightOperator.onScrollEnd"
-      | "rightOperator.onFocus"
-      | "rightOperator.onBlur"
-      | "row.remove"
-      | "row.add";
-    value?:
-      | string
-      | { value: string; label: string }[]
-      | { label: string; value: string };
-    path?: string;
-    rowType?: string;
-  };
+  detail?:
+    | {
+        type: "row.add";
+        rowType: string;
+      }
+    | {
+        type: "row.remove";
+        path: string;
+      }
+    | {
+        type: "leftOperator.onChange";
+        path: string;
+        value: { label: string; value: string; type: string };
+        rowType: string;
+      }
+    | {
+        type: "leftOperator.onFocus";
+        path: string;
+      }
+    | {
+        type: "leftOperator.onBlur";
+        path: string;
+      }
+    | {
+        type: "leftOperator.onInputValueChange";
+        path: string;
+        value: string;
+      }
+    | {
+        type: "condition.onChange";
+        path: string;
+        value: { label: string; value: string; type: string };
+      }
+    | {
+        type: "condition.onFocus";
+        path: string;
+      }
+    | {
+        type: "condition.onBlur";
+        path: string;
+      }
+    | {
+        type: "rightOperator.onChange";
+        path: string;
+        value:
+          | string
+          | { label: string; value: string; type: string }[]
+          | { label: string; value: string; type: string };
+      }
+    | {
+        type: "rightOperator.onFocus";
+        path: string;
+      }
+    | {
+        type: "rightOperator.onBlur";
+        path: string;
+      }
+    | {
+        type: "rightOperator.onInputValueChange";
+        path: string;
+        value: string;
+      };
 }
 
 type UseEventsProps = {


### PR DESCRIPTION
I want to merge this change because it exports `FilterEvent` type from experimental filters.

This PR closes #...

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

- [ ] New components are exported from `./src/components/index.ts`.
- [ ] Storybook story is created and documentation properly generated.
