### PR TITLE
feat: allow passing generic options to selects

### DIFF
--- a/src/components/BaseSelect/types.ts
+++ b/src/components/BaseSelect/types.ts
@@ -1,3 +1,3 @@
 export type Option = { label: string; value: string };
-export type SingleChangeHandler = (selectedItem: Option) => void;
-export type MultiChangeHandler = (selectedItems: Option[]) => void;
+export type SingleChangeHandler<O> = (selectedItem: O) => void;
+export type MultiChangeHandler<O> = (selectedItems: O[]) => void;

--- a/src/components/BaseSelect/types.ts
+++ b/src/components/BaseSelect/types.ts
@@ -1,3 +1,3 @@
 export type Option = { label: string; value: string };
-export type SingleChangeHandler<O> = (selectedItem: O) => void;
-export type MultiChangeHandler<O> = (selectedItems: O[]) => void;
+export type SingleChangeHandler<T> = (selectedItem: T) => void;
+export type MultiChangeHandler<T> = (selectedItems: T[]) => void;

--- a/src/components/Combobox/Common/useCombobox.tsx
+++ b/src/components/Combobox/Common/useCombobox.tsx
@@ -7,7 +7,10 @@ import {
 
 import { Option, SingleChangeHandler } from "~/components/BaseSelect";
 
-const getItemsFilter = (inputValue: string | undefined, options: Option[]) => {
+const getItemsFilter = <O extends Option>(
+  inputValue: string | undefined,
+  options: O[]
+) => {
   if (!inputValue) {
     return options;
   }
@@ -19,7 +22,7 @@ const getItemsFilter = (inputValue: string | undefined, options: Option[]) => {
   );
 };
 
-export const useCombobox = ({
+export const useCombobox = <O extends Option>({
   selectedItem,
   options,
   onChange,
@@ -27,9 +30,9 @@ export const useCombobox = ({
   onFocus,
   onBlur,
 }: {
-  selectedItem: Option | null;
-  options: Option[];
-  onChange?: SingleChangeHandler;
+  selectedItem: O | null;
+  options: O[];
+  onChange?: SingleChangeHandler<O>;
   onInputValueChange?: (value: string) => void;
   onFocus?: (e: FocusEvent<HTMLInputElement, Element>) => void;
   onBlur?: (e: FocusEvent<HTMLInputElement, Element>) => void;
@@ -38,7 +41,7 @@ export const useCombobox = ({
   const [active, setActive] = useState(false);
   const typed = Boolean(selectedItem || active || inputValue);
 
-  const itemsToSelect = getItemsFilter(inputValue, options);
+  const itemsToSelect = getItemsFilter<O>(inputValue, options);
 
   const {
     isOpen,

--- a/src/components/Combobox/Common/useCombobox.tsx
+++ b/src/components/Combobox/Common/useCombobox.tsx
@@ -7,9 +7,9 @@ import {
 
 import { Option, SingleChangeHandler } from "~/components/BaseSelect";
 
-const getItemsFilter = <O extends Option>(
+const getItemsFilter = <T extends Option>(
   inputValue: string | undefined,
-  options: O[]
+  options: T[]
 ) => {
   if (!inputValue) {
     return options;
@@ -22,7 +22,7 @@ const getItemsFilter = <O extends Option>(
   );
 };
 
-export const useCombobox = <O extends Option>({
+export const useCombobox = <T extends Option>({
   selectedItem,
   options,
   onChange,
@@ -30,9 +30,9 @@ export const useCombobox = <O extends Option>({
   onFocus,
   onBlur,
 }: {
-  selectedItem: O | null;
-  options: O[];
-  onChange?: SingleChangeHandler<O>;
+  selectedItem: T | null;
+  options: T[];
+  onChange?: SingleChangeHandler<T>;
   onInputValueChange?: (value: string) => void;
   onFocus?: (e: FocusEvent<HTMLInputElement, Element>) => void;
   onBlur?: (e: FocusEvent<HTMLInputElement, Element>) => void;
@@ -41,7 +41,7 @@ export const useCombobox = <O extends Option>({
   const [active, setActive] = useState(false);
   const typed = Boolean(selectedItem || active || inputValue);
 
-  const itemsToSelect = getItemsFilter<O>(inputValue, options);
+  const itemsToSelect = getItemsFilter<T>(inputValue, options);
 
   const {
     isOpen,

--- a/src/components/Combobox/Dynamic/DynamicCombobox.tsx
+++ b/src/components/Combobox/Dynamic/DynamicCombobox.tsx
@@ -1,5 +1,11 @@
 import { Root as Portal } from "@radix-ui/react-portal";
-import { forwardRef, InputHTMLAttributes, ReactNode, useRef } from "react";
+import {
+  ForwardedRef,
+  forwardRef,
+  InputHTMLAttributes,
+  ReactNode,
+  useRef,
+} from "react";
 
 import { classNames } from "~/utils";
 
@@ -18,7 +24,7 @@ import {
 import { useCombobox } from "../Common/useCombobox";
 import { ComboboxWrapper } from "../Common/ComboboxWrapper";
 
-export type DynamicComboboxProps = PropsWithBox<
+export type DynamicComboboxProps<O> = PropsWithBox<
   Omit<
     InputHTMLAttributes<HTMLInputElement>,
     | "color"
@@ -35,9 +41,9 @@ export type DynamicComboboxProps = PropsWithBox<
     label?: ReactNode;
     error?: boolean;
     helperText?: ReactNode;
-    options: Option[];
-    onChange?: SingleChangeHandler;
-    value: Option | null;
+    options: O[];
+    onChange?: SingleChangeHandler<O>;
+    value: O | null;
     onInputValueChange?: (value: string) => void;
     loading?: boolean;
     locale?: {
@@ -47,128 +53,129 @@ export type DynamicComboboxProps = PropsWithBox<
 > &
   InputVariants;
 
-export const DynamicCombobox = forwardRef<
-  HTMLInputElement,
-  DynamicComboboxProps
->(
-  (
-    {
-      size,
-      disabled = false,
-      className,
-      value,
-      label,
-      id,
-      error = false,
-      helperText,
-      options,
-      onChange,
-      onInputValueChange,
-      onFocus,
-      onBlur,
-      loading,
-      locale = {
-        loadingText: "Loading",
-      },
-      ...props
+const DynamicComboboxInner = <O extends Option>(
+  {
+    size,
+    disabled = false,
+    className,
+    value,
+    label,
+    id,
+    error = false,
+    helperText,
+    options,
+    onChange,
+    onInputValueChange,
+    onFocus,
+    onBlur,
+    loading,
+    locale = {
+      loadingText: "Loading",
     },
-    ref
-  ) => {
-    const {
-      active,
-      typed,
-      isOpen,
-      getToggleButtonProps,
-      getLabelProps,
-      getMenuProps,
-      getInputProps,
-      highlightedIndex,
-      getItemProps,
-      itemsToSelect,
-      hasItemsToSelect,
-    } = useCombobox({
-      selectedItem: value,
-      options,
-      onChange,
-      onInputValueChange,
-      onFocus,
-      onBlur,
-    });
+    ...props
+  }: DynamicComboboxProps<O>,
+  ref: ForwardedRef<HTMLInputElement>
+) => {
+  const {
+    active,
+    typed,
+    isOpen,
+    getToggleButtonProps,
+    getLabelProps,
+    getMenuProps,
+    getInputProps,
+    highlightedIndex,
+    getItemProps,
+    itemsToSelect,
+    hasItemsToSelect,
+  } = useCombobox({
+    selectedItem: value,
+    options,
+    onChange,
+    onInputValueChange,
+    onFocus,
+    onBlur,
+  });
 
-    const containerRef = useRef<HTMLLabelElement>(null);
+  const containerRef = useRef<HTMLLabelElement>(null);
 
-    return (
-      <Box display="flex" flexDirection="column">
-        <ComboboxWrapper
+  return (
+    <Box display="flex" flexDirection="column">
+      <ComboboxWrapper
+        id={id}
+        typed={typed}
+        active={active}
+        disabled={disabled}
+        size={size}
+        label={label}
+        error={error}
+        className={className}
+        getLabelProps={getLabelProps}
+        getToggleButtonProps={getToggleButtonProps}
+      >
+        <Box
           id={id}
-          typed={typed}
-          active={active}
+          as="input"
+          type="text"
+          className={classNames(inputRecipe({ size, error }))}
           disabled={disabled}
-          size={size}
-          label={label}
-          error={error}
-          className={className}
-          getLabelProps={getLabelProps}
-          getToggleButtonProps={getToggleButtonProps}
+          {...props}
+          {...getInputProps({
+            id,
+            ref,
+          })}
+        />
+      </ComboboxWrapper>
+      <Box ref={containerRef} />
+
+      <Portal asChild container={containerRef.current}>
+        <Box
+          position="relative"
+          display={getListDisplayMode({ isOpen, hasItemsToSelect, loading })}
+          className={listWrapperRecipe({ size })}
         >
-          <Box
-            id={id}
-            as="input"
-            type="text"
-            className={classNames(inputRecipe({ size, error }))}
-            disabled={disabled}
-            {...props}
-            {...getInputProps({
-              id,
-              ref,
-            })}
-          />
-        </ComboboxWrapper>
-        <Box ref={containerRef} />
-
-        <Portal asChild container={containerRef.current}>
-          <Box
-            position="relative"
-            display={getListDisplayMode({ isOpen, hasItemsToSelect, loading })}
-            className={listWrapperRecipe({ size })}
+          <List
+            as="ul"
+            className={listStyle}
+            // suppress error because of rendering list in portal
+            {...getMenuProps({}, { suppressRefError: true })}
           >
-            <List
-              as="ul"
-              className={listStyle}
-              // suppress error because of rendering list in portal
-              {...getMenuProps({}, { suppressRefError: true })}
-            >
-              {isOpen &&
-                itemsToSelect?.map((item, index) => (
-                  <List.Item
-                    key={`${id}-${item}-${index}`}
-                    className={listItemStyle}
-                    {...getItemProps({
-                      item,
-                      index,
-                    })}
-                    active={highlightedIndex === index}
-                  >
-                    <Text size={size}>{item.label}</Text>
-                  </List.Item>
-                ))}
-              {loading && (
-                <LoadingListItem size={size}>
-                  {locale.loadingText}
-                </LoadingListItem>
-              )}
-            </List>
-          </Box>
-        </Portal>
+            {isOpen &&
+              itemsToSelect?.map((item, index) => (
+                <List.Item
+                  key={`${id}-${item}-${index}`}
+                  className={listItemStyle}
+                  {...getItemProps({
+                    item,
+                    index,
+                  })}
+                  active={highlightedIndex === index}
+                >
+                  <Text size={size}>{item.label}</Text>
+                </List.Item>
+              ))}
+            {loading && (
+              <LoadingListItem size={size}>
+                {locale.loadingText}
+              </LoadingListItem>
+            )}
+          </List>
+        </Box>
+      </Portal>
 
-        {helperText && (
-          <HelperText size={size} error={error}>
-            {helperText}
-          </HelperText>
-        )}
-      </Box>
-    );
+      {helperText && (
+        <HelperText size={size} error={error}>
+          {helperText}
+        </HelperText>
+      )}
+    </Box>
+  );
+};
+
+export const DynamicCombobox = forwardRef(DynamicComboboxInner) as <
+  O extends Option
+>(
+  props: DynamicComboboxProps<O> & {
+    ref?: React.ForwardedRef<HTMLInputElement>;
   }
-);
-
-DynamicCombobox.displayName = "DynamicCombobox";
+) => ReturnType<typeof DynamicComboboxInner>;

--- a/src/components/Combobox/Dynamic/DynamicCombobox.tsx
+++ b/src/components/Combobox/Dynamic/DynamicCombobox.tsx
@@ -24,7 +24,7 @@ import {
 import { useCombobox } from "../Common/useCombobox";
 import { ComboboxWrapper } from "../Common/ComboboxWrapper";
 
-export type DynamicComboboxProps<O> = PropsWithBox<
+export type DynamicComboboxProps<T> = PropsWithBox<
   Omit<
     InputHTMLAttributes<HTMLInputElement>,
     | "color"
@@ -41,9 +41,9 @@ export type DynamicComboboxProps<O> = PropsWithBox<
     label?: ReactNode;
     error?: boolean;
     helperText?: ReactNode;
-    options: O[];
-    onChange?: SingleChangeHandler<O>;
-    value: O | null;
+    options: T[];
+    onChange?: SingleChangeHandler<T>;
+    value: T | null;
     onInputValueChange?: (value: string) => void;
     loading?: boolean;
     locale?: {
@@ -53,7 +53,7 @@ export type DynamicComboboxProps<O> = PropsWithBox<
 > &
   InputVariants;
 
-const DynamicComboboxInner = <O extends Option>(
+const DynamicComboboxInner = <T extends Option>(
   {
     size,
     disabled = false,
@@ -73,7 +73,7 @@ const DynamicComboboxInner = <O extends Option>(
       loadingText: "Loading",
     },
     ...props
-  }: DynamicComboboxProps<O>,
+  }: DynamicComboboxProps<T>,
   ref: ForwardedRef<HTMLInputElement>
 ) => {
   const {
@@ -88,7 +88,7 @@ const DynamicComboboxInner = <O extends Option>(
     getItemProps,
     itemsToSelect,
     hasItemsToSelect,
-  } = useCombobox<O>({
+  } = useCombobox<T>({
     selectedItem: value,
     options,
     onChange,
@@ -173,9 +173,9 @@ const DynamicComboboxInner = <O extends Option>(
 };
 
 export const DynamicCombobox = forwardRef(DynamicComboboxInner) as <
-  O extends Option
+  T extends Option
 >(
-  props: DynamicComboboxProps<O> & {
+  props: DynamicComboboxProps<T> & {
     ref?: React.ForwardedRef<HTMLInputElement>;
   }
 ) => ReturnType<typeof DynamicComboboxInner>;

--- a/src/components/Combobox/Dynamic/DynamicCombobox.tsx
+++ b/src/components/Combobox/Dynamic/DynamicCombobox.tsx
@@ -88,7 +88,7 @@ const DynamicComboboxInner = <O extends Option>(
     getItemProps,
     itemsToSelect,
     hasItemsToSelect,
-  } = useCombobox({
+  } = useCombobox<O>({
     selectedItem: value,
     options,
     onChange,

--- a/src/components/Combobox/Static/Combobox.tsx
+++ b/src/components/Combobox/Static/Combobox.tsx
@@ -1,5 +1,11 @@
 import { Root as Portal } from "@radix-ui/react-portal";
-import { InputHTMLAttributes, ReactNode, forwardRef, useRef } from "react";
+import {
+  ForwardedRef,
+  InputHTMLAttributes,
+  ReactNode,
+  forwardRef,
+  useRef,
+} from "react";
 
 import { classNames } from "~/utils";
 import { Box, List, PropsWithBox, Text } from "~/components";
@@ -14,7 +20,7 @@ import {
 
 import { ComboboxWrapper, useCombobox } from "../Common";
 
-export type ComboboxProps = PropsWithBox<
+export type ComboboxProps<O> = PropsWithBox<
   Omit<
     InputHTMLAttributes<HTMLInputElement>,
     | "color"
@@ -31,121 +37,121 @@ export type ComboboxProps = PropsWithBox<
     label?: ReactNode;
     error?: boolean;
     helperText?: ReactNode;
-    options: Option[];
-    onChange?: SingleChangeHandler;
-    value: Option | null;
+    options: O[];
+    onChange?: SingleChangeHandler<O>;
+    value: O | null;
   }
 > &
   InputVariants;
 
-export const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(
-  (
-    {
-      size,
-      disabled = false,
-      className,
-      value,
-      label,
-      id,
-      error = false,
-      helperText,
-      options,
-      onChange,
-      onFocus,
-      onBlur,
-      ...props
-    },
-    ref
-  ) => {
-    const {
-      active,
-      typed,
-      isOpen,
-      getToggleButtonProps,
-      getLabelProps,
-      getMenuProps,
-      getInputProps,
-      highlightedIndex,
-      getItemProps,
-      itemsToSelect,
-      hasItemsToSelect,
-    } = useCombobox({
-      selectedItem: value,
-      options,
-      onChange,
-      onFocus,
-      onBlur,
-    });
+const ComboboxInner = <O extends Option>(
+  {
+    size,
+    disabled = false,
+    className,
+    value,
+    label,
+    id,
+    error = false,
+    helperText,
+    options,
+    onChange,
+    onFocus,
+    onBlur,
+    ...props
+  }: ComboboxProps<O>,
+  ref: ForwardedRef<HTMLInputElement>
+) => {
+  const {
+    active,
+    typed,
+    isOpen,
+    getToggleButtonProps,
+    getLabelProps,
+    getMenuProps,
+    getInputProps,
+    highlightedIndex,
+    getItemProps,
+    itemsToSelect,
+    hasItemsToSelect,
+  } = useCombobox({
+    selectedItem: value,
+    options,
+    onChange,
+    onFocus,
+    onBlur,
+  });
 
-    const containerRef = useRef<HTMLLabelElement>(null);
+  const containerRef = useRef<HTMLLabelElement>(null);
 
-    return (
-      <Box display="flex" flexDirection="column">
-        <ComboboxWrapper
+  return (
+    <Box display="flex" flexDirection="column">
+      <ComboboxWrapper
+        id={id}
+        typed={typed}
+        active={active}
+        disabled={disabled}
+        size={size}
+        label={label}
+        error={error}
+        className={className}
+        getLabelProps={getLabelProps}
+        getToggleButtonProps={getToggleButtonProps}
+      >
+        <Box
           id={id}
-          typed={typed}
-          active={active}
+          as="input"
+          type="text"
+          className={classNames(inputRecipe({ size, error }))}
           disabled={disabled}
-          size={size}
-          label={label}
-          error={error}
-          className={className}
-          getLabelProps={getLabelProps}
-          getToggleButtonProps={getToggleButtonProps}
+          {...props}
+          {...getInputProps({
+            id,
+            ref,
+          })}
+        />
+      </ComboboxWrapper>
+      <Box ref={containerRef} />
+
+      <Portal asChild container={containerRef.current}>
+        <Box
+          position="relative"
+          display={isOpen && hasItemsToSelect ? "block" : "none"}
+          className={listWrapperRecipe({ size })}
         >
-          <Box
-            id={id}
-            as="input"
-            type="text"
-            className={classNames(inputRecipe({ size, error }))}
-            disabled={disabled}
-            {...props}
-            {...getInputProps({
-              id,
-              ref,
-            })}
-          />
-        </ComboboxWrapper>
-        <Box ref={containerRef} />
-
-        <Portal asChild container={containerRef.current}>
-          <Box
-            position="relative"
-            display={isOpen && hasItemsToSelect ? "block" : "none"}
-            className={listWrapperRecipe({ size })}
+          <List
+            as="ul"
+            className={listStyle}
+            // suppress error because of rendering list in portal
+            {...getMenuProps({}, { suppressRefError: true })}
           >
-            <List
-              as="ul"
-              className={listStyle}
-              // suppress error because of rendering list in portal
-              {...getMenuProps({}, { suppressRefError: true })}
-            >
-              {isOpen &&
-                itemsToSelect?.map((item, index) => (
-                  <List.Item
-                    key={`${id}-${item}-${index}`}
-                    className={listItemStyle}
-                    {...getItemProps({
-                      item,
-                      index,
-                    })}
-                    active={highlightedIndex === index}
-                  >
-                    <Text size={size}>{item.label}</Text>
-                  </List.Item>
-                ))}
-            </List>
-          </Box>
-        </Portal>
+            {isOpen &&
+              itemsToSelect?.map((item, index) => (
+                <List.Item
+                  key={`${id}-${item}-${index}`}
+                  className={listItemStyle}
+                  {...getItemProps({
+                    item,
+                    index,
+                  })}
+                  active={highlightedIndex === index}
+                >
+                  <Text size={size}>{item.label}</Text>
+                </List.Item>
+              ))}
+          </List>
+        </Box>
+      </Portal>
 
-        {helperText && (
-          <HelperText size={size} error={error}>
-            {helperText}
-          </HelperText>
-        )}
-      </Box>
-    );
-  }
-);
+      {helperText && (
+        <HelperText size={size} error={error}>
+          {helperText}
+        </HelperText>
+      )}
+    </Box>
+  );
+};
 
-Combobox.displayName = "Combobox";
+export const Combobox = forwardRef(ComboboxInner) as <O extends Option>(
+  props: ComboboxProps<O> & { ref?: React.ForwardedRef<HTMLInputElement> }
+) => ReturnType<typeof ComboboxInner>;

--- a/src/components/Combobox/Static/Combobox.tsx
+++ b/src/components/Combobox/Static/Combobox.tsx
@@ -20,7 +20,7 @@ import {
 
 import { ComboboxWrapper, useCombobox } from "../Common";
 
-export type ComboboxProps<O> = PropsWithBox<
+export type ComboboxProps<T> = PropsWithBox<
   Omit<
     InputHTMLAttributes<HTMLInputElement>,
     | "color"
@@ -37,14 +37,14 @@ export type ComboboxProps<O> = PropsWithBox<
     label?: ReactNode;
     error?: boolean;
     helperText?: ReactNode;
-    options: O[];
-    onChange?: SingleChangeHandler<O>;
-    value: O | null;
+    options: T[];
+    onChange?: SingleChangeHandler<T>;
+    value: T | null;
   }
 > &
   InputVariants;
 
-const ComboboxInner = <O extends Option>(
+const ComboboxInner = <T extends Option>(
   {
     size,
     disabled = false,
@@ -59,7 +59,7 @@ const ComboboxInner = <O extends Option>(
     onFocus,
     onBlur,
     ...props
-  }: ComboboxProps<O>,
+  }: ComboboxProps<T>,
   ref: ForwardedRef<HTMLInputElement>
 ) => {
   const {
@@ -152,6 +152,6 @@ const ComboboxInner = <O extends Option>(
   );
 };
 
-export const Combobox = forwardRef(ComboboxInner) as <O extends Option>(
-  props: ComboboxProps<O> & { ref?: React.ForwardedRef<HTMLInputElement> }
+export const Combobox = forwardRef(ComboboxInner) as <T extends Option>(
+  props: ComboboxProps<T> & { ref?: React.ForwardedRef<HTMLInputElement> }
 ) => ReturnType<typeof ComboboxInner>;

--- a/src/components/Multiselect/Common/useMultiselect.tsx
+++ b/src/components/Multiselect/Common/useMultiselect.tsx
@@ -14,10 +14,10 @@ export type RenderEndAdornmentType = (
   ...props: ReturnType<UseComboboxPropGetters<Option>["getToggleButtonProps"]>
 ) => ReactNode;
 
-const getItemsFilter = (
-  selectedItems: Option[],
+const getItemsFilter = <O extends Option>(
+  selectedItems: O[],
   inputValue: string,
-  options: Option[]
+  options: O[]
 ) => {
   const lowerCasedInputValue = inputValue?.toLowerCase();
 
@@ -29,7 +29,7 @@ const getItemsFilter = (
   );
 };
 
-export const useMultiselect = ({
+export const useMultiselect = <O extends Option>({
   selectedItems,
   options,
   onChange,
@@ -37,9 +37,9 @@ export const useMultiselect = ({
   onFocus,
   onBlur,
 }: {
-  selectedItems: Option[];
-  options: Option[];
-  onChange?: MultiChangeHandler;
+  selectedItems: O[];
+  options: O[];
+  onChange?: MultiChangeHandler<O>;
   onInputValueChange?: (value: string) => void;
   onFocus?: (e: FocusEvent<HTMLInputElement, Element>) => void;
   onBlur?: (e: FocusEvent<HTMLInputElement, Element>) => void;
@@ -47,7 +47,7 @@ export const useMultiselect = ({
   const [inputValue, setInputValue] = useState("");
   const [active, setActive] = useState(false);
 
-  const itemsToSelect = getItemsFilter(selectedItems, inputValue, options);
+  const itemsToSelect = getItemsFilter<O>(selectedItems, inputValue, options);
 
   const showInput = onInputValueChange
     ? true

--- a/src/components/Multiselect/Common/useMultiselect.tsx
+++ b/src/components/Multiselect/Common/useMultiselect.tsx
@@ -14,10 +14,10 @@ export type RenderEndAdornmentType = (
   ...props: ReturnType<UseComboboxPropGetters<Option>["getToggleButtonProps"]>
 ) => ReactNode;
 
-const getItemsFilter = <O extends Option>(
-  selectedItems: O[],
+const getItemsFilter = <T extends Option>(
+  selectedItems: T[],
   inputValue: string,
-  options: O[]
+  options: T[]
 ) => {
   const lowerCasedInputValue = inputValue?.toLowerCase();
 
@@ -29,7 +29,7 @@ const getItemsFilter = <O extends Option>(
   );
 };
 
-export const useMultiselect = <O extends Option>({
+export const useMultiselect = <T extends Option>({
   selectedItems,
   options,
   onChange,
@@ -37,9 +37,9 @@ export const useMultiselect = <O extends Option>({
   onFocus,
   onBlur,
 }: {
-  selectedItems: O[];
-  options: O[];
-  onChange?: MultiChangeHandler<O>;
+  selectedItems: T[];
+  options: T[];
+  onChange?: MultiChangeHandler<T>;
   onInputValueChange?: (value: string) => void;
   onFocus?: (e: FocusEvent<HTMLInputElement, Element>) => void;
   onBlur?: (e: FocusEvent<HTMLInputElement, Element>) => void;
@@ -47,7 +47,7 @@ export const useMultiselect = <O extends Option>({
   const [inputValue, setInputValue] = useState("");
   const [active, setActive] = useState(false);
 
-  const itemsToSelect = getItemsFilter<O>(selectedItems, inputValue, options);
+  const itemsToSelect = getItemsFilter<T>(selectedItems, inputValue, options);
 
   const showInput = onInputValueChange
     ? true

--- a/src/components/Multiselect/Dynamic/DynamicMultiselect.tsx
+++ b/src/components/Multiselect/Dynamic/DynamicMultiselect.tsx
@@ -26,7 +26,7 @@ import {
   multiselectInputRecipe,
 } from "../Common";
 
-export type DynamicMultiselectProps<O> = PropsWithBox<
+export type DynamicMultiselectProps<T> = PropsWithBox<
   Omit<
     InputHTMLAttributes<HTMLInputElement>,
     | "color"
@@ -43,9 +43,9 @@ export type DynamicMultiselectProps<O> = PropsWithBox<
     label?: ReactNode;
     error?: boolean;
     helperText?: ReactNode;
-    options: O[];
-    onChange?: MultiChangeHandler<O>;
-    value: O[];
+    options: T[];
+    onChange?: MultiChangeHandler<T>;
+    value: T[];
     renderEndAdornment?: RenderEndAdornmentType;
     onInputValueChange?: (value: string) => void;
     loading?: boolean;
@@ -57,7 +57,7 @@ export type DynamicMultiselectProps<O> = PropsWithBox<
 > &
   InputVariants;
 
-const DynamicMultiselectInner = <O extends Option>(
+const DynamicMultiselectInner = <T extends Option>(
   {
     size,
     disabled = false,
@@ -79,7 +79,7 @@ const DynamicMultiselectInner = <O extends Option>(
       inputText: "Add item",
     },
     ...props
-  }: DynamicMultiselectProps<O>,
+  }: DynamicMultiselectProps<T>,
   ref: ForwardedRef<HTMLInputElement>
 ) => {
   const {
@@ -99,7 +99,7 @@ const DynamicMultiselectInner = <O extends Option>(
     getToggleButtonProps,
     hasItemsToSelect,
     showInput,
-  } = useMultiselect<O>({
+  } = useMultiselect<T>({
     selectedItems: value,
     onInputValueChange,
     options,
@@ -234,9 +234,9 @@ const DynamicMultiselectInner = <O extends Option>(
 };
 
 export const DynamicMultiselect = forwardRef(DynamicMultiselectInner) as <
-  O extends Option
+  T extends Option
 >(
-  props: DynamicMultiselectProps<O> & {
+  props: DynamicMultiselectProps<T> & {
     ref?: React.ForwardedRef<HTMLInputElement>;
   }
 ) => ReturnType<typeof DynamicMultiselectInner>;

--- a/src/components/Multiselect/Dynamic/DynamicMultiselect.tsx
+++ b/src/components/Multiselect/Dynamic/DynamicMultiselect.tsx
@@ -99,7 +99,7 @@ const DynamicMultiselectInner = <O extends Option>(
     getToggleButtonProps,
     hasItemsToSelect,
     showInput,
-  } = useMultiselect({
+  } = useMultiselect<O>({
     selectedItems: value,
     onInputValueChange,
     options,

--- a/src/components/Multiselect/Dynamic/DynamicMultiselect.tsx
+++ b/src/components/Multiselect/Dynamic/DynamicMultiselect.tsx
@@ -1,5 +1,11 @@
 import { Root as Portal } from "@radix-ui/react-portal";
-import { forwardRef, InputHTMLAttributes, ReactNode, useRef } from "react";
+import {
+  ForwardedRef,
+  forwardRef,
+  InputHTMLAttributes,
+  ReactNode,
+  useRef,
+} from "react";
 
 import { Box, List, PropsWithBox, Text } from "~/components";
 import { HelperText, InputVariants } from "~/components/BaseInput";
@@ -20,7 +26,7 @@ import {
   multiselectInputRecipe,
 } from "../Common";
 
-export type DynamicMultiselectProps = PropsWithBox<
+export type DynamicMultiselectProps<O> = PropsWithBox<
   Omit<
     InputHTMLAttributes<HTMLInputElement>,
     | "color"
@@ -37,9 +43,9 @@ export type DynamicMultiselectProps = PropsWithBox<
     label?: ReactNode;
     error?: boolean;
     helperText?: ReactNode;
-    options: Option[];
-    onChange?: MultiChangeHandler;
-    value: Option[];
+    options: O[];
+    onChange?: MultiChangeHandler<O>;
+    value: O[];
     renderEndAdornment?: RenderEndAdornmentType;
     onInputValueChange?: (value: string) => void;
     loading?: boolean;
@@ -51,185 +57,186 @@ export type DynamicMultiselectProps = PropsWithBox<
 > &
   InputVariants;
 
-export const DynamicMultiselect = forwardRef<
-  HTMLInputElement,
-  DynamicMultiselectProps
->(
-  (
-    {
-      size,
-      disabled = false,
-      className,
-      label,
-      id,
-      error = false,
-      helperText,
-      options,
-      onChange,
-      renderEndAdornment,
-      value = [],
-      onInputValueChange,
-      loading,
-      onFocus,
-      onBlur,
-      locale = {
-        loadingText: "Loading",
-        inputText: "Add item",
-      },
-      ...props
+const DynamicMultiselectInner = <O extends Option>(
+  {
+    size,
+    disabled = false,
+    className,
+    label,
+    id,
+    error = false,
+    helperText,
+    options,
+    onChange,
+    renderEndAdornment,
+    value = [],
+    onInputValueChange,
+    loading,
+    onFocus,
+    onBlur,
+    locale = {
+      loadingText: "Loading",
+      inputText: "Add item",
     },
-    ref
-  ) => {
-    const {
-      active,
-      typed,
-      isOpen,
-      getLabelProps,
-      getMenuProps,
-      getInputProps,
-      highlightedIndex,
-      getItemProps,
-      itemsToSelect,
-      selectedItems,
-      getSelectedItemProps,
-      inputValue,
-      removeSelectedItem,
-      getToggleButtonProps,
-      hasItemsToSelect,
-      showInput,
-    } = useMultiselect({
-      selectedItems: value,
-      onInputValueChange,
-      options,
-      onChange,
-      onFocus,
-      onBlur,
-    });
+    ...props
+  }: DynamicMultiselectProps<O>,
+  ref: ForwardedRef<HTMLInputElement>
+) => {
+  const {
+    active,
+    typed,
+    isOpen,
+    getLabelProps,
+    getMenuProps,
+    getInputProps,
+    highlightedIndex,
+    getItemProps,
+    itemsToSelect,
+    selectedItems,
+    getSelectedItemProps,
+    inputValue,
+    removeSelectedItem,
+    getToggleButtonProps,
+    hasItemsToSelect,
+    showInput,
+  } = useMultiselect({
+    selectedItems: value,
+    onInputValueChange,
+    options,
+    onChange,
+    onFocus,
+    onBlur,
+  });
 
-    const containerRef = useRef<HTMLDivElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
 
-    return (
-      <Box display="flex" flexDirection="column">
-        <MultiselectWrapper
-          id={id}
-          typed={typed}
-          active={active}
-          disabled={disabled}
-          size={size}
-          label={label}
-          error={error}
-          className={className}
-          getLabelProps={getLabelProps}
-          getToggleButtonProps={getToggleButtonProps}
-          renderEndAdornment={renderEndAdornment}
-          hasItemsToSelect={hasItemsToSelect}
-        >
-          {selectedItems.map((item, idx) => (
-            <Box
-              key={`selected-item-${item}-${idx}`}
-              paddingX={1.5}
-              paddingY={0.5}
-              backgroundColor="surfaceNeutralSubdued"
-              borderColor="neutralHighlight"
-              borderWidth={1}
-              borderStyle="solid"
-              borderRadius={3}
-              display="flex"
-              gap={1}
-              alignItems="center"
-              {...getSelectedItemProps({
-                selectedItem: item,
-                index: idx,
-              })}
-            >
-              <Text
-                variant="caption"
-                size={size === "small" ? "small" : "medium"}
-              >
-                {item.label}
-              </Text>
-              {!disabled && (
-                <Text
-                  cursor="pointer"
-                  variant="caption"
-                  size="small"
-                  marginBottom="px"
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    event.preventDefault();
-                    removeSelectedItem(item);
-                  }}
-                >
-                  &#10005;
-                </Text>
-              )}
-            </Box>
-          ))}
-
+  return (
+    <Box display="flex" flexDirection="column">
+      <MultiselectWrapper
+        id={id}
+        typed={typed}
+        active={active}
+        disabled={disabled}
+        size={size}
+        label={label}
+        error={error}
+        className={className}
+        getLabelProps={getLabelProps}
+        getToggleButtonProps={getToggleButtonProps}
+        renderEndAdornment={renderEndAdornment}
+        hasItemsToSelect={hasItemsToSelect}
+      >
+        {selectedItems.map((item, idx) => (
           <Box
-            id={id}
-            as="input"
-            className={multiselectInputRecipe({ size, error })}
-            placeholder={locale.inputText}
-            disabled={disabled}
-            width={0}
-            __flex={1}
-            minWidth={7}
-            visibility={showInput ? "visible" : "hidden"}
-            {...getInputProps({
-              id,
-              ref,
-              value: inputValue,
+            key={`selected-item-${item}-${idx}`}
+            paddingX={1.5}
+            paddingY={0.5}
+            backgroundColor="surfaceNeutralSubdued"
+            borderColor="neutralHighlight"
+            borderWidth={1}
+            borderStyle="solid"
+            borderRadius={3}
+            display="flex"
+            gap={1}
+            alignItems="center"
+            {...getSelectedItemProps({
+              selectedItem: item,
+              index: idx,
             })}
-            {...props}
-          />
-        </MultiselectWrapper>
-
-        <Box ref={containerRef} />
-
-        <Portal asChild container={containerRef.current}>
-          <Box
-            position="relative"
-            display={getListDisplayMode({ isOpen, hasItemsToSelect, loading })}
-            className={listWrapperRecipe({ size })}
           >
-            <List
-              as="ul"
-              className={listStyle}
-              // suppress error because of rendering list in portal
-              {...getMenuProps({}, { suppressRefError: true })}
+            <Text
+              variant="caption"
+              size={size === "small" ? "small" : "medium"}
             >
-              {isOpen &&
-                itemsToSelect?.map((item, index) => (
-                  <List.Item
-                    key={`to-select-${id}-${item}-${index}`}
-                    className={listItemStyle}
-                    active={highlightedIndex === index}
-                    {...getItemProps({
-                      item,
-                      index,
-                    })}
-                  >
-                    <Text size={size}>{item.label}</Text>
-                  </List.Item>
-                ))}
-              {loading && (
-                <LoadingListItem size={size}>
-                  {locale.loadingText}
-                </LoadingListItem>
-              )}
-            </List>
+              {item.label}
+            </Text>
+            {!disabled && (
+              <Text
+                cursor="pointer"
+                variant="caption"
+                size="small"
+                marginBottom="px"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  event.preventDefault();
+                  removeSelectedItem(item);
+                }}
+              >
+                &#10005;
+              </Text>
+            )}
           </Box>
-        </Portal>
+        ))}
 
-        {helperText && (
-          <HelperText size={size} error={error}>
-            {helperText}
-          </HelperText>
-        )}
-      </Box>
-    );
+        <Box
+          id={id}
+          as="input"
+          className={multiselectInputRecipe({ size, error })}
+          placeholder={locale.inputText}
+          disabled={disabled}
+          width={0}
+          __flex={1}
+          minWidth={7}
+          visibility={showInput ? "visible" : "hidden"}
+          {...getInputProps({
+            id,
+            ref,
+            value: inputValue,
+          })}
+          {...props}
+        />
+      </MultiselectWrapper>
+
+      <Box ref={containerRef} />
+
+      <Portal asChild container={containerRef.current}>
+        <Box
+          position="relative"
+          display={getListDisplayMode({ isOpen, hasItemsToSelect, loading })}
+          className={listWrapperRecipe({ size })}
+        >
+          <List
+            as="ul"
+            className={listStyle}
+            // suppress error because of rendering list in portal
+            {...getMenuProps({}, { suppressRefError: true })}
+          >
+            {isOpen &&
+              itemsToSelect?.map((item, index) => (
+                <List.Item
+                  key={`to-select-${id}-${item}-${index}`}
+                  className={listItemStyle}
+                  active={highlightedIndex === index}
+                  {...getItemProps({
+                    item,
+                    index,
+                  })}
+                >
+                  <Text size={size}>{item.label}</Text>
+                </List.Item>
+              ))}
+            {loading && (
+              <LoadingListItem size={size}>
+                {locale.loadingText}
+              </LoadingListItem>
+            )}
+          </List>
+        </Box>
+      </Portal>
+
+      {helperText && (
+        <HelperText size={size} error={error}>
+          {helperText}
+        </HelperText>
+      )}
+    </Box>
+  );
+};
+
+export const DynamicMultiselect = forwardRef(DynamicMultiselectInner) as <
+  O extends Option
+>(
+  props: DynamicMultiselectProps<O> & {
+    ref?: React.ForwardedRef<HTMLInputElement>;
   }
-);
-
-DynamicMultiselect.displayName = "DynamicMultiselect";
+) => ReturnType<typeof DynamicMultiselectInner>;

--- a/src/components/Multiselect/Static/Multiselect.tsx
+++ b/src/components/Multiselect/Static/Multiselect.tsx
@@ -91,7 +91,7 @@ const MultiselectInner = <O extends Option>(
     getToggleButtonProps,
     hasItemsToSelect,
     showInput,
-  } = useMultiselect({
+  } = useMultiselect<O>({
     selectedItems: value,
     options,
     onChange,

--- a/src/components/Multiselect/Static/Multiselect.tsx
+++ b/src/components/Multiselect/Static/Multiselect.tsx
@@ -24,7 +24,7 @@ import {
   multiselectInputRecipe,
 } from "../Common";
 
-export type MultiselectProps<O> = PropsWithBox<
+export type MultiselectProps<T> = PropsWithBox<
   Omit<
     InputHTMLAttributes<HTMLInputElement>,
     | "color"
@@ -41,9 +41,9 @@ export type MultiselectProps<O> = PropsWithBox<
     label?: ReactNode;
     error?: boolean;
     helperText?: ReactNode;
-    options: O[];
-    onChange?: MultiChangeHandler<O>;
-    value: O[];
+    options: T[];
+    onChange?: MultiChangeHandler<T>;
+    value: T[];
     renderEndAdornment?: RenderEndAdornmentType;
     locale?: {
       inputText?: string;
@@ -52,7 +52,7 @@ export type MultiselectProps<O> = PropsWithBox<
 > &
   InputVariants;
 
-const MultiselectInner = <O extends Option>(
+const MultiselectInner = <T extends Option>(
   {
     size,
     disabled = false,
@@ -71,7 +71,7 @@ const MultiselectInner = <O extends Option>(
       inputText: "Add item",
     },
     ...props
-  }: MultiselectProps<O>,
+  }: MultiselectProps<T>,
   ref: ForwardedRef<HTMLInputElement>
 ) => {
   const {
@@ -91,7 +91,7 @@ const MultiselectInner = <O extends Option>(
     getToggleButtonProps,
     hasItemsToSelect,
     showInput,
-  } = useMultiselect<O>({
+  } = useMultiselect<T>({
     selectedItems: value,
     options,
     onChange,
@@ -219,6 +219,6 @@ const MultiselectInner = <O extends Option>(
   );
 };
 
-export const Multiselect = forwardRef(MultiselectInner) as <O extends Option>(
-  props: MultiselectProps<O> & { ref?: React.ForwardedRef<HTMLInputElement> }
+export const Multiselect = forwardRef(MultiselectInner) as <T extends Option>(
+  props: MultiselectProps<T> & { ref?: React.ForwardedRef<HTMLInputElement> }
 ) => ReturnType<typeof MultiselectInner>;

--- a/src/components/Multiselect/Static/Multiselect.tsx
+++ b/src/components/Multiselect/Static/Multiselect.tsx
@@ -1,5 +1,11 @@
 import { Root as Portal } from "@radix-ui/react-portal";
-import { forwardRef, InputHTMLAttributes, ReactNode, useRef } from "react";
+import {
+  ForwardedRef,
+  forwardRef,
+  InputHTMLAttributes,
+  ReactNode,
+  useRef,
+} from "react";
 
 import { Box, List, PropsWithBox, Text } from "~/components";
 import { HelperText, InputVariants } from "~/components/BaseInput";
@@ -18,7 +24,7 @@ import {
   multiselectInputRecipe,
 } from "../Common";
 
-export type MultiselectProps = PropsWithBox<
+export type MultiselectProps<O> = PropsWithBox<
   Omit<
     InputHTMLAttributes<HTMLInputElement>,
     | "color"
@@ -35,9 +41,9 @@ export type MultiselectProps = PropsWithBox<
     label?: ReactNode;
     error?: boolean;
     helperText?: ReactNode;
-    options: Option[];
-    onChange?: MultiChangeHandler;
-    value: Option[];
+    options: O[];
+    onChange?: MultiChangeHandler<O>;
+    value: O[];
     renderEndAdornment?: RenderEndAdornmentType;
     locale?: {
       inputText?: string;
@@ -46,173 +52,173 @@ export type MultiselectProps = PropsWithBox<
 > &
   InputVariants;
 
-export const Multiselect = forwardRef<HTMLInputElement, MultiselectProps>(
-  (
-    {
-      size,
-      disabled = false,
-      className,
-      label,
-      id,
-      error = false,
-      helperText,
-      options,
-      onChange,
-      renderEndAdornment,
-      value = [],
-      onFocus,
-      onBlur,
-      locale = {
-        inputText: "Add item",
-      },
-      ...props
+const MultiselectInner = <O extends Option>(
+  {
+    size,
+    disabled = false,
+    className,
+    label,
+    id,
+    error = false,
+    helperText,
+    options,
+    onChange,
+    renderEndAdornment,
+    value = [],
+    onFocus,
+    onBlur,
+    locale = {
+      inputText: "Add item",
     },
-    ref
-  ) => {
-    const {
-      active,
-      typed,
-      isOpen,
-      getLabelProps,
-      getMenuProps,
-      getInputProps,
-      highlightedIndex,
-      getItemProps,
-      itemsToSelect,
-      selectedItems,
-      getSelectedItemProps,
-      inputValue,
-      removeSelectedItem,
-      getToggleButtonProps,
-      hasItemsToSelect,
-      showInput,
-    } = useMultiselect({
-      selectedItems: value,
-      options,
-      onChange,
-      onFocus,
-      onBlur,
-    });
+    ...props
+  }: MultiselectProps<O>,
+  ref: ForwardedRef<HTMLInputElement>
+) => {
+  const {
+    active,
+    typed,
+    isOpen,
+    getLabelProps,
+    getMenuProps,
+    getInputProps,
+    highlightedIndex,
+    getItemProps,
+    itemsToSelect,
+    selectedItems,
+    getSelectedItemProps,
+    inputValue,
+    removeSelectedItem,
+    getToggleButtonProps,
+    hasItemsToSelect,
+    showInput,
+  } = useMultiselect({
+    selectedItems: value,
+    options,
+    onChange,
+    onFocus,
+    onBlur,
+  });
 
-    const containerRef = useRef<HTMLDivElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
 
-    return (
-      <Box display="flex" flexDirection="column">
-        <MultiselectWrapper
-          id={id}
-          typed={typed}
-          active={active}
-          disabled={disabled}
-          size={size}
-          label={label}
-          error={error}
-          className={className}
-          getLabelProps={getLabelProps}
-          getToggleButtonProps={getToggleButtonProps}
-          renderEndAdornment={renderEndAdornment}
-          hasItemsToSelect={hasItemsToSelect}
-        >
-          {selectedItems.map((item, idx) => (
-            <Box
-              key={`selected-item-${item}-${idx}`}
-              paddingX={1.5}
-              paddingY={0.5}
-              backgroundColor="surfaceNeutralSubdued"
-              borderColor="neutralHighlight"
-              borderWidth={1}
-              borderStyle="solid"
-              borderRadius={3}
-              display="flex"
-              gap={1}
-              alignItems="center"
-              {...getSelectedItemProps({
-                selectedItem: item,
-                index: idx,
-              })}
-            >
-              <Text
-                variant="caption"
-                size={size === "small" ? "small" : "medium"}
-              >
-                {item.label}
-              </Text>
-              {!disabled && (
-                <Text
-                  cursor="pointer"
-                  variant="caption"
-                  size="small"
-                  marginBottom="px"
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    event.preventDefault();
-                    removeSelectedItem(item);
-                  }}
-                >
-                  &#10005;
-                </Text>
-              )}
-            </Box>
-          ))}
-
+  return (
+    <Box display="flex" flexDirection="column">
+      <MultiselectWrapper
+        id={id}
+        typed={typed}
+        active={active}
+        disabled={disabled}
+        size={size}
+        label={label}
+        error={error}
+        className={className}
+        getLabelProps={getLabelProps}
+        getToggleButtonProps={getToggleButtonProps}
+        renderEndAdornment={renderEndAdornment}
+        hasItemsToSelect={hasItemsToSelect}
+      >
+        {selectedItems.map((item, idx) => (
           <Box
-            id={id}
-            as="input"
-            className={multiselectInputRecipe({ size, error })}
-            placeholder={locale.inputText}
-            disabled={disabled}
-            width={0}
-            __flex={1}
-            minWidth={7}
-            visibility={showInput ? "visible" : "hidden"}
-            {...getInputProps({
-              id,
-              ref,
-              value: inputValue,
+            key={`selected-item-${item}-${idx}`}
+            paddingX={1.5}
+            paddingY={0.5}
+            backgroundColor="surfaceNeutralSubdued"
+            borderColor="neutralHighlight"
+            borderWidth={1}
+            borderStyle="solid"
+            borderRadius={3}
+            display="flex"
+            gap={1}
+            alignItems="center"
+            {...getSelectedItemProps({
+              selectedItem: item,
+              index: idx,
             })}
-            {...props}
-          />
-        </MultiselectWrapper>
-
-        <Box ref={containerRef} />
-
-        <Portal asChild container={containerRef.current}>
-          <Box
-            position="relative"
-            display={isOpen && hasItemsToSelect ? "block" : "none"}
-            className={listWrapperRecipe({ size })}
           >
-            <List
-              as="ul"
-              className={listStyle}
-              // suppress error because of rendering list in portal
-              {...getMenuProps({}, { suppressRefError: true })}
+            <Text
+              variant="caption"
+              size={size === "small" ? "small" : "medium"}
             >
-              {isOpen &&
-                itemsToSelect?.map((item, index) => (
-                  <List.Item
-                    key={`to-select-${id}-${item}-${index}`}
-                    className={listItemStyle}
-                    active={highlightedIndex === index}
-                    {...getItemProps({
-                      item,
-                      index,
-                    })}
-                  >
-                    <Text size={size}>{item.label}</Text>
-                  </List.Item>
-                ))}
-            </List>
+              {item.label}
+            </Text>
+            {!disabled && (
+              <Text
+                cursor="pointer"
+                variant="caption"
+                size="small"
+                marginBottom="px"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  event.preventDefault();
+                  removeSelectedItem(item);
+                }}
+              >
+                &#10005;
+              </Text>
+            )}
           </Box>
-        </Portal>
+        ))}
 
-        {helperText && (
-          <HelperText size={size} error={error}>
-            {helperText}
-          </HelperText>
-        )}
-      </Box>
-    );
-  }
-);
+        <Box
+          id={id}
+          as="input"
+          className={multiselectInputRecipe({ size, error })}
+          placeholder={locale.inputText}
+          disabled={disabled}
+          width={0}
+          __flex={1}
+          minWidth={7}
+          visibility={showInput ? "visible" : "hidden"}
+          {...getInputProps({
+            id,
+            ref,
+            value: inputValue,
+          })}
+          {...props}
+        />
+      </MultiselectWrapper>
 
-Multiselect.displayName = "Multiselect";
+      <Box ref={containerRef} />
+
+      <Portal asChild container={containerRef.current}>
+        <Box
+          position="relative"
+          display={isOpen && hasItemsToSelect ? "block" : "none"}
+          className={listWrapperRecipe({ size })}
+        >
+          <List
+            as="ul"
+            className={listStyle}
+            // suppress error because of rendering list in portal
+            {...getMenuProps({}, { suppressRefError: true })}
+          >
+            {isOpen &&
+              itemsToSelect?.map((item, index) => (
+                <List.Item
+                  key={`to-select-${id}-${item}-${index}`}
+                  className={listItemStyle}
+                  active={highlightedIndex === index}
+                  {...getItemProps({
+                    item,
+                    index,
+                  })}
+                >
+                  <Text size={size}>{item.label}</Text>
+                </List.Item>
+              ))}
+          </List>
+        </Box>
+      </Portal>
+
+      {helperText && (
+        <HelperText size={size} error={error}>
+          {helperText}
+        </HelperText>
+      )}
+    </Box>
+  );
+};
+
+export const Multiselect = forwardRef(MultiselectInner) as <O extends Option>(
+  props: MultiselectProps<O> & { ref?: React.ForwardedRef<HTMLInputElement> }
+) => ReturnType<typeof MultiselectInner>;

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -140,13 +140,3 @@ const [value, setValue] = useState("color-black");
     },
   },
 };
-
-export const Test = () => {
-  return (
-    <Select
-      value={null}
-      options={[{ label: "", value: "", slug: "" }]}
-      onChange={(value) => console.log(value)}
-    />
-  );
-};

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -140,3 +140,13 @@ const [value, setValue] = useState("color-black");
     },
   },
 };
+
+export const Test = () => {
+  return (
+    <Select
+      value={null}
+      options={[{ label: "", value: "", slug: "" }]}
+      onChange={(value) => console.log(value)}
+    />
+  );
+};

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -20,7 +20,7 @@ import {
 import { SelectWrapper } from "./SelectWrapper";
 import { useSelect } from "./useSelect";
 
-export type SelectProps<O> = PropsWithBox<
+export type SelectProps<T> = PropsWithBox<
   Omit<
     InputHTMLAttributes<HTMLElement>,
     | "color"
@@ -36,9 +36,9 @@ export type SelectProps<O> = PropsWithBox<
     label?: ReactNode;
     error?: boolean;
     helperText?: ReactNode;
-    options: O[];
-    onChange?: SingleChangeHandler<O>;
-    value: O | null;
+    options: T[];
+    onChange?: SingleChangeHandler<T>;
+    value: T | null;
     locale?: {
       loadingText?: string;
     };
@@ -57,7 +57,7 @@ const getBoxHeight = (size: "small" | "medium" | "large") => {
   }
 };
 
-const SelectInner = <O extends Option>(
+const SelectInner = <T extends Option>(
   {
     size = "medium",
     disabled = false,
@@ -72,7 +72,7 @@ const SelectInner = <O extends Option>(
     onFocus,
     onBlur,
     ...props
-  }: SelectProps<O>,
+  }: SelectProps<T>,
   ref: ForwardedRef<HTMLElement>
 ) => {
   const {
@@ -157,6 +157,6 @@ const SelectInner = <O extends Option>(
   );
 };
 
-export const Select = forwardRef(SelectInner) as <O extends Option>(
-  props: SelectProps<O> & { ref?: React.ForwardedRef<HTMLElement> }
+export const Select = forwardRef(SelectInner) as <T extends Option>(
+  props: SelectProps<T> & { ref?: React.ForwardedRef<HTMLElement> }
 ) => ReturnType<typeof SelectInner>;

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -1,5 +1,11 @@
 import { Root as Portal } from "@radix-ui/react-portal";
-import { InputHTMLAttributes, ReactNode, forwardRef, useRef } from "react";
+import {
+  ForwardedRef,
+  InputHTMLAttributes,
+  ReactNode,
+  forwardRef,
+  useRef,
+} from "react";
 
 import { Box, List, PropsWithBox, Text } from "..";
 import { HelperText, InputVariants } from "../BaseInput";
@@ -14,7 +20,7 @@ import {
 import { SelectWrapper } from "./SelectWrapper";
 import { useSelect } from "./useSelect";
 
-export type SelectProps = PropsWithBox<
+export type SelectProps<O> = PropsWithBox<
   Omit<
     InputHTMLAttributes<HTMLElement>,
     | "color"
@@ -30,9 +36,9 @@ export type SelectProps = PropsWithBox<
     label?: ReactNode;
     error?: boolean;
     helperText?: ReactNode;
-    options: Option[];
-    onChange?: SingleChangeHandler;
-    value: Option | null;
+    options: O[];
+    onChange?: SingleChangeHandler<O>;
+    value: O | null;
     locale?: {
       loadingText?: string;
     };
@@ -40,7 +46,7 @@ export type SelectProps = PropsWithBox<
 > &
   InputVariants;
 
-const getBoxHeight = (size: SelectProps["size"]) => {
+const getBoxHeight = (size: "small" | "medium" | "large") => {
   switch (size) {
     case "small":
       return 4;
@@ -51,106 +57,106 @@ const getBoxHeight = (size: SelectProps["size"]) => {
   }
 };
 
-export const Select = forwardRef<HTMLElement, SelectProps>(
-  (
-    {
-      size = "medium",
-      disabled = false,
-      className,
-      value,
-      label,
-      id,
-      error = false,
-      helperText,
-      options,
-      onChange,
-      onFocus,
-      onBlur,
-      ...props
-    },
-    ref
-  ) => {
-    const {
-      active,
-      typed,
-      isOpen,
-      getItemProps,
-      getLabelProps,
-      getToggleButtonProps,
-      selectedItem,
-      getMenuProps,
-      highlightedIndex,
-      hasItemsToSelect,
-    } = useSelect({
-      value,
-      options,
-      onChange,
-      onFocus,
-      onBlur,
-    });
+const SelectInner = <O extends Option>(
+  {
+    size = "medium",
+    disabled = false,
+    className,
+    value,
+    label,
+    id,
+    error = false,
+    helperText,
+    options,
+    onChange,
+    onFocus,
+    onBlur,
+    ...props
+  }: SelectProps<O>,
+  ref: ForwardedRef<HTMLElement>
+) => {
+  const {
+    active,
+    typed,
+    isOpen,
+    getItemProps,
+    getLabelProps,
+    getToggleButtonProps,
+    selectedItem,
+    getMenuProps,
+    highlightedIndex,
+    hasItemsToSelect,
+  } = useSelect({
+    value,
+    options,
+    onChange,
+    onFocus,
+    onBlur,
+  });
 
-    const containerRef = useRef<HTMLLabelElement>(null);
+  const containerRef = useRef<HTMLLabelElement>(null);
 
-    return (
-      <Box display="flex" flexDirection="column">
-        <SelectWrapper
-          id={id}
-          typed={typed}
-          active={active}
-          disabled={disabled}
-          size={size}
-          label={label}
-          error={error}
-          className={className}
-          getLabelProps={getLabelProps}
-          getToggleButtonProps={getToggleButtonProps}
+  return (
+    <Box display="flex" flexDirection="column">
+      <SelectWrapper
+        id={id}
+        typed={typed}
+        active={active}
+        disabled={disabled}
+        size={size}
+        label={label}
+        error={error}
+        className={className}
+        getLabelProps={getLabelProps}
+        getToggleButtonProps={getToggleButtonProps}
+      >
+        <Box height={getBoxHeight(size)} {...props} ref={ref}>
+          <Text size={size} variant="body">
+            {selectedItem?.label}
+          </Text>
+        </Box>
+      </SelectWrapper>
+      <Box ref={containerRef} />
+
+      <Portal asChild container={containerRef.current}>
+        <Box
+          position="relative"
+          display={isOpen && hasItemsToSelect ? "block" : "none"}
+          className={listWrapperRecipe({ size })}
         >
-          <Box height={getBoxHeight(size)} {...props} ref={ref}>
-            <Text size={size} variant="body">
-              {selectedItem?.label}
-            </Text>
-          </Box>
-        </SelectWrapper>
-        <Box ref={containerRef} />
-
-        <Portal asChild container={containerRef.current}>
-          <Box
-            position="relative"
-            display={isOpen && hasItemsToSelect ? "block" : "none"}
-            className={listWrapperRecipe({ size })}
+          <List
+            as="ul"
+            className={listStyle}
+            // suppress error because of rendering list in portal
+            {...getMenuProps({}, { suppressRefError: true })}
           >
-            <List
-              as="ul"
-              className={listStyle}
-              // suppress error because of rendering list in portal
-              {...getMenuProps({}, { suppressRefError: true })}
-            >
-              {isOpen &&
-                options?.map((item, index) => (
-                  <List.Item
-                    key={`${id}-${item}-${index}`}
-                    className={listItemStyle}
-                    {...getItemProps({
-                      item,
-                      index,
-                    })}
-                    active={highlightedIndex === index}
-                  >
-                    <Text size={size}>{item.label}</Text>
-                  </List.Item>
-                ))}
-            </List>
-          </Box>
-        </Portal>
+            {isOpen &&
+              options?.map((item, index) => (
+                <List.Item
+                  key={`${id}-${item}-${index}`}
+                  className={listItemStyle}
+                  {...getItemProps({
+                    item,
+                    index,
+                  })}
+                  active={highlightedIndex === index}
+                >
+                  <Text size={size}>{item.label}</Text>
+                </List.Item>
+              ))}
+          </List>
+        </Box>
+      </Portal>
 
-        {helperText && (
-          <HelperText size={size} error={error}>
-            {helperText}
-          </HelperText>
-        )}
-      </Box>
-    );
-  }
-);
+      {helperText && (
+        <HelperText size={size} error={error}>
+          {helperText}
+        </HelperText>
+      )}
+    </Box>
+  );
+};
 
-Select.displayName = "Select";
+export const Select = forwardRef(SelectInner) as <O extends Option>(
+  props: SelectProps<O> & { ref?: React.ForwardedRef<HTMLElement> }
+) => ReturnType<typeof SelectInner>;

--- a/src/components/Select/useSelect.tsx
+++ b/src/components/Select/useSelect.tsx
@@ -7,16 +7,16 @@ import {
 
 import { Option, SingleChangeHandler } from "../BaseSelect";
 
-export const useSelect = ({
+export const useSelect = <O extends Option>({
   value,
   options,
   onChange,
   onFocus,
   onBlur,
 }: {
-  value: Option | null;
-  options: Option[];
-  onChange?: SingleChangeHandler;
+  value: O | null;
+  options: O[];
+  onChange?: SingleChangeHandler<O>;
   onFocus?: (e: FocusEvent<HTMLElement, Element>) => void;
   onBlur?: (e: FocusEvent<HTMLElement, Element>) => void;
 }) => {

--- a/src/components/Select/useSelect.tsx
+++ b/src/components/Select/useSelect.tsx
@@ -7,16 +7,16 @@ import {
 
 import { Option, SingleChangeHandler } from "../BaseSelect";
 
-export const useSelect = <O extends Option>({
+export const useSelect = <T extends Option>({
   value,
   options,
   onChange,
   onFocus,
   onBlur,
 }: {
-  value: O | null;
-  options: O[];
-  onChange?: SingleChangeHandler<O>;
+  value: T | null;
+  options: T[];
+  onChange?: SingleChangeHandler<T>;
   onFocus?: (e: FocusEvent<HTMLElement, Element>) => void;
   onBlur?: (e: FocusEvent<HTMLElement, Element>) => void;
 }) => {


### PR DESCRIPTION
I want to merge this change because is the ability to pass additional fields to select/combobox/multiselect options.

For example, after this PR is closed it will be possible to:
```tsx
    <Select
	  // value inferred from options - in this case { label: string, value: string, slug: string }
      value={null}
      options={[{ label: "", value: "", slug: "" }]}
	  // newValue inferred from options - in this case { label: string, value: string, slug: string }
      onChange={(newValue) => {}}
    />
  );
```

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

- [ ] New components are exported from `./src/components/index.ts`.
- [ ] Storybook story is created and documentation properly generated.
