### PR TITLE
fix: exported types for npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   "bugs": {
     "url": "https://github.com/saleor/macaw-ui/issues"
   },
-  "type": "module",
   "files": [
     "dist/*",
     "legacy/dist/*"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ESNext",
+    "target": "ES2021",
     "useDefineForClassFields": true,
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "allowJs": false,
@@ -9,8 +9,7 @@
     "allowSyntheticDefaultImports": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,
-    "module": "ESNext",
-    "moduleResolution": "Node",
+    "module": "commonjs",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,


### PR DESCRIPTION
I want to merge this change because it fixes npm bundle errors for `/next` package

This PR closes #489 

After this PR is merged:
![CleanShot 2023-07-07 at 10 40 54@2x](https://github.com/saleor/macaw-ui/assets/9116238/6e5961ea-d58c-46b3-8931-8bf544661a88)


### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

- [ ] New components are exported from `./src/components/index.ts`.
- [ ] Storybook story is created and documentation properly generated.
