### PR TITLE
feat: change width of exp filter row export loading skeleton

### DIFF
--- a/src/components/ExperimentalFilters/ExperimentalFilters.stories.tsx
+++ b/src/components/ExperimentalFilters/ExperimentalFilters.stories.tsx
@@ -8,7 +8,6 @@ import { Row, _ExperimentalFilters } from ".";
 
 const meta: Meta<typeof _ExperimentalFilters> = {
   title: "Components / _ExperimentalFilters",
-  tags: ["autodocs"],
   component: _ExperimentalFilters,
 };
 

--- a/src/components/ExperimentalFilters/Row.tsx
+++ b/src/components/ExperimentalFilters/Row.tsx
@@ -43,7 +43,7 @@ export const Row = ({
     <Box
       display="grid"
       gap={0.5}
-      __gridTemplateColumns="200px 200px 200px auto"
+      __gridTemplateColumns="200px 120px 200px auto"
       placeItems="center"
     >
       <DynamicCombobox

--- a/src/components/ExperimentalFilters/index.ts
+++ b/src/components/ExperimentalFilters/index.ts
@@ -10,9 +10,11 @@ export type {
 
 import { Root } from "./Root";
 import { AddRowButton, ConfirmButton, Footer } from "./Footer";
+import { Skeleton } from "./Skeleton";
 
 export const _ExperimentalFilters = Object.assign(Root, {
   AddRowButton,
   ConfirmButton,
   Footer,
+  Skeleton,
 });


### PR DESCRIPTION
I want to merge this change because it adjusts the width of the condition selected in the experimental row. I also added export for loading skeleton.

This PR closes #...

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->
| Before | After |
| ------- | ------- |
| ![CleanShot 2023-07-12 at 17 03 55@2x](https://github.com/saleor/macaw-ui/assets/9116238/3184e98d-5d3b-4f81-8675-6b9358358737)| ![CleanShot 2023-07-13 at 09 14 01@2x](https://github.com/saleor/macaw-ui/assets/9116238/bb4e10a6-cdd1-49fa-b594-2244be5ab948) |
  
### Pull Request Checklist

- [ ] New components are exported from `./src/components/index.ts`.
- [ ] Storybook story is created and documentation properly generated.
