### PR TITLE
feat: experimental filters - add error state and constrains

### DIFF
--- a/src/components/BaseInput/BaseInput.css.ts
+++ b/src/components/BaseInput/BaseInput.css.ts
@@ -272,6 +272,9 @@ export const helperTextRecipe = recipe({
       }),
     },
   },
+  defaultVariants: {
+    size: "medium",
+  },
 });
 
 export type LabelVariants = RecipeVariants<typeof labelRecipe>;

--- a/src/components/BaseInput/HelperText.tsx
+++ b/src/components/BaseInput/HelperText.tsx
@@ -10,7 +10,7 @@ type HelperTextProps = {
 
 export const HelperText = ({ size, error, children }: HelperTextProps) => {
   return (
-    <Box marginTop={3} className={helperTextRecipe({ size })}>
+    <Box className={helperTextRecipe({ size })}>
       <Text
         variant="caption"
         size={size}

--- a/src/components/ExperimentalFilters/EventEmitter.ts
+++ b/src/components/ExperimentalFilters/EventEmitter.ts
@@ -1,112 +1,20 @@
-import { Option } from "..";
-
-export type RightOperatorOption = Option & {
-  slug: string;
-};
-
-export type LeftOperatorOption = Option & {
-  type: string;
-};
-
-export type ConditionOption<T extends string> = Option & {
-  type: T;
-};
-
-export type RowAddData = {
-  type: "row.add";
-  rowType: string;
-};
-
-export type RowRemoveData = {
-  type: "row.remove";
-  path: `${number}`;
-  index: number;
-};
-
-export type LeftOperatorChangeData = {
-  type: "leftOperator.onChange";
-  path: `${number}`;
-  index: number;
-  value: LeftOperatorOption;
-  rowType: string;
-};
-
-export type LeftOperatorFocusData = {
-  type: "leftOperator.onFocus";
-  path: `${number}`;
-  index: number;
-};
-
-export type LeftOperatorBlurData = {
-  type: "leftOperator.onBlur";
-  path: `${number}`;
-  index: number;
-};
-
-export type LeftOperatorInputValueChangeData = {
-  type: "leftOperator.onInputValueChange";
-  path: `${number}`;
-  index: number;
-  value: string;
-};
-
-export type ConditionChangeData = {
-  type: "condition.onChange";
-  path: `${number}.condition.selected`;
-  index: number;
-  value: ConditionOption<
-    | "text"
-    | "number"
-    | "multiselect"
-    | "combobox"
-    | "select"
-    | "number.range"
-    | "date"
-    | "datetime"
-  >;
-};
-
-export type ConditionFocusData = {
-  type: "condition.onFocus";
-  path: `${number}.condition.selected`;
-  index: number;
-};
-
-export type ConditionBlurData = {
-  type: "condition.onBlur";
-  path: `${number}.condition.selected`;
-  index: number;
-};
-
-export type RightOperatorChangeData = {
-  type: "rightOperator.onChange";
-  path: `${number}.condition.selected.value`;
-  index: number;
-  value:
-    | string
-    | RightOperatorOption[]
-    | RightOperatorOption
-    | [string, string];
-};
-
-export type RightOperatorFocusData = {
-  type: "rightOperator.onFocus";
-  path: `${number}.condition.selected.value`;
-  index: number;
-};
-
-export type RightOperatorBlurData = {
-  type: "rightOperator.onBlur";
-  path: `${number}.condition.selected.value`;
-  index: number;
-};
-
-export type RightOperatorInputValueChangeData = {
-  type: "rightOperator.onInputValueChange";
-  path: `${number}.condition.selected.value`;
-  index: number;
-  value: string;
-};
+import {
+  ConditionBlurData,
+  ConditionChangeData,
+  ConditionFocusData,
+  LeftOperatorBlurData,
+  LeftOperatorChangeData,
+  LeftOperatorFocusData,
+  LeftOperatorInputValueChangeData,
+  LeftOperatorOption,
+  RightOperatorBlurData,
+  RightOperatorChangeData,
+  RightOperatorFocusData,
+  RightOperatorInputValueChangeData,
+  RightOperatorOption,
+  RowAddData,
+  RowRemoveData,
+} from "./types";
 
 export class FilterEventEmitter extends EventTarget {
   type = "filterChange";

--- a/src/components/ExperimentalFilters/EventEmitter.ts
+++ b/src/components/ExperimentalFilters/EventEmitter.ts
@@ -45,7 +45,7 @@ export class FilterEventEmitter extends EventTarget {
   changeLeftOperator(
     index: number,
     value: LeftOperatorOption,
-    rowType: string
+    rowType: string | undefined
   ) {
     this.dispatchEvent(
       new CustomEvent<LeftOperatorChangeData>(this.type, {
@@ -53,7 +53,7 @@ export class FilterEventEmitter extends EventTarget {
           type: "leftOperator.onChange",
           path: `${index}`,
           value,
-          rowType,
+          rowType: rowType ?? "",
           index,
         },
       })

--- a/src/components/ExperimentalFilters/ExperimentalFilters.stories.tsx
+++ b/src/components/ExperimentalFilters/ExperimentalFilters.stories.tsx
@@ -1,10 +1,18 @@
 import { Meta } from "@storybook/react";
 import _ from "lodash";
-import { useState } from "react";
+import { ReactNode, useState } from "react";
 
-import { Box, Text, Button, Popover, CloseIcon, Divider } from "..";
-import { Skeleton } from "./Skeleton";
-import { RowComponent, _ExperimentalFilters } from ".";
+import {
+  Box,
+  Text,
+  Button,
+  Popover,
+  CloseIcon,
+  Divider,
+  PropsWithBox,
+} from "..";
+
+import { Row, _ExperimentalFilters } from ".";
 
 const meta: Meta<typeof _ExperimentalFilters> = {
   title: "Components / _ExperimentalFilters",
@@ -20,7 +28,7 @@ const leftOptions = [
   { value: "discount", label: "Discount", type: "4" },
 ];
 
-const value = [
+const defaultValue = [
   {
     value: { value: "price", label: "Price", type: "1" },
     condition: {
@@ -97,141 +105,10 @@ const value = [
   },
 ] as Array<Row | string>;
 
-const commonHeaderProps = {
-  paddingTop: 3,
-  paddingX: 3,
-  paddingBottom: 1.5,
-  display: "flex",
-  gap: 1,
-  alignItems: "center",
-  justifyContent: "space-between",
-  backgroundColor: "surfaceNeutralPlain",
-  borderTopLeftRadius: 2,
-  borderTopRightRadius: 2,
-} as const;
-
-const commonFilterProps = {
-  padding: 3,
-  backgroundColor: "interactiveNeutralSecondaryHovering",
-  borderBottomLeftRadius: 2,
-  borderBottomRightRadius: 2,
-} as const;
-
-const Filters = () => {
-  const [rows, setRows] = useState<Array<Row | string>>(value);
-
-  return (
-    <_ExperimentalFilters
-      value={rows}
-      leftOptions={leftOptions}
-      onChange={(event) => {
-        if (event?.type === "rightOperator.onChange") {
-          const newState = _.setWith(
-            _.clone(rows),
-            event?.path ?? "",
-            event?.value,
-            _.clone
-          );
-          setRows(newState);
-        }
-
-        if (event?.type === "condition.onChange") {
-          const newState = _.setWith(
-            _.clone(rows),
-            event?.path ?? "",
-            {
-              value: [],
-              options: [
-                { value: "electronics", label: "Electronics" },
-                { value: "clothing", label: "Clothing" },
-              ],
-              conditionValue: event?.value,
-            },
-            _.clone
-          );
-          setRows(newState);
-        }
-
-        if (event?.type === "leftOperator.onChange") {
-          const newState = _.setWith(
-            _.clone(rows),
-            event?.path ?? "",
-            {
-              value: event?.value,
-              condition: {
-                options: [
-                  { type: "number", label: "is", value: "input-1" },
-                  {
-                    type: "multiselect",
-                    label: "has",
-                    value: "input-2",
-                  },
-                ],
-                selected: {
-                  value: "",
-                  conditionValue: {
-                    type: "number",
-                    label: "is",
-                    value: "input-1",
-                  },
-                },
-              },
-            },
-            _.clone
-          );
-          setRows(newState);
-        }
-        if (event?.type === "row.add") {
-          const newState = [
-            ...rows,
-            {
-              value: null,
-              condition: {
-                options: [],
-                selected: {
-                  value: "",
-                  conditionValue: null,
-                  options: [],
-                },
-              },
-            },
-          ];
-          setRows(newState);
-        }
-
-        if (event?.type === "row.remove") {
-          const index = parseInt(event?.path ?? "", 10);
-          if (index === 0) {
-            const newState = [...rows.slice(index + 2, rows.length)];
-            setRows(newState);
-            return;
-          }
-          const newState = [
-            ...rows.slice(0, index - 1),
-            ...rows.slice(index + 1, rows.length),
-          ];
-          setRows(newState);
-        }
-      }}
-    >
-      <_ExperimentalFilters.Footer>
-        <_ExperimentalFilters.AddRowButton>
-          Add row
-        </_ExperimentalFilters.AddRowButton>
-        <Box display="flex" gap={3}>
-          <_ExperimentalFilters.ClearButton>
-            Clear
-          </_ExperimentalFilters.ClearButton>
-          <_ExperimentalFilters.ConfirmButton onClick={() => ({})}>
-            Save
-          </_ExperimentalFilters.ConfirmButton>
-        </Box>
-      </_ExperimentalFilters.Footer>
-    </_ExperimentalFilters>
-  );
-};
-
-export const Default = () => {
+const Template = ({
+  children,
+  ...props
+}: PropsWithBox<{ children: ReactNode }>) => {
   return (
     <Popover>
       <Popover.Trigger>
@@ -244,7 +121,18 @@ export const Default = () => {
           display="grid"
           __gridTemplateRows="auto 1fr"
         >
-          <Box {...commonHeaderProps}>
+          <Box
+            paddingTop={3}
+            paddingX={3}
+            paddingBottom={1.5}
+            display="flex"
+            gap={1}
+            alignItems="center"
+            justifyContent="space-between"
+            backgroundColor="surfaceNeutralPlain"
+            borderTopLeftRadius={2}
+            borderTopRightRadius={2}
+          >
             <Text variant="body" size="medium">
               Conditions
             </Text>
@@ -254,133 +142,184 @@ export const Default = () => {
               </Popover.Close>
             </Box>
           </Box>
-          <Box {...commonFilterProps}>
-            <Filters />
+          <Box
+            padding={3}
+            backgroundColor="interactiveNeutralSecondaryHovering"
+            borderBottomLeftRadius={2}
+            borderBottomRightRadius={2}
+            {...props}
+          >
+            {children}
           </Box>
         </Box>
       </Popover.Content>
     </Popover>
+  );
+};
+
+export const Default = () => {
+  const [rows, setRows] = useState(defaultValue);
+
+  return (
+    <Template>
+      <_ExperimentalFilters
+        value={rows}
+        leftOptions={leftOptions}
+        onChange={(event) => {
+          if (event?.type === "rightOperator.onChange") {
+            const newState = _.setWith(
+              _.clone(rows),
+              event?.path ?? "",
+              event?.value,
+              _.clone
+            );
+            setRows(newState);
+          }
+
+          if (event?.type === "condition.onChange") {
+            const newState = _.setWith(
+              _.clone(rows),
+              event?.path ?? "",
+              {
+                value: [],
+                options: [
+                  { value: "electronics", label: "Electronics" },
+                  { value: "clothing", label: "Clothing" },
+                ],
+                conditionValue: event?.value,
+              },
+              _.clone
+            );
+            setRows(newState);
+          }
+
+          if (event?.type === "leftOperator.onChange") {
+            const newState = _.setWith(
+              _.clone(rows),
+              event?.path ?? "",
+              {
+                value: event?.value,
+                condition: {
+                  options: [
+                    { type: "number", label: "is", value: "input-1" },
+                    {
+                      type: "multiselect",
+                      label: "has",
+                      value: "input-2",
+                    },
+                  ],
+                  selected: {
+                    value: "",
+                    conditionValue: {
+                      type: "number",
+                      label: "is",
+                      value: "input-1",
+                    },
+                  },
+                },
+              },
+              _.clone
+            );
+            setRows(newState);
+          }
+          if (event?.type === "row.add") {
+            const newState = [
+              ...rows,
+              {
+                value: null,
+                condition: {
+                  options: [],
+                  selected: {
+                    value: "",
+                    conditionValue: null,
+                    options: [],
+                  },
+                },
+              },
+            ];
+            setRows(newState);
+          }
+
+          if (event?.type === "row.remove") {
+            const index = parseInt(event?.path ?? "", 10);
+            if (index === 0) {
+              const newState = [...rows.slice(index + 2, rows.length)];
+              setRows(newState);
+              return;
+            }
+            const newState = [
+              ...rows.slice(0, index - 1),
+              ...rows.slice(index + 1, rows.length),
+            ];
+            setRows(newState);
+          }
+        }}
+      >
+        <_ExperimentalFilters.Footer>
+          <_ExperimentalFilters.AddRowButton>
+            Add row
+          </_ExperimentalFilters.AddRowButton>
+          <Box display="flex" gap={3}>
+            <_ExperimentalFilters.ClearButton>
+              Clear
+            </_ExperimentalFilters.ClearButton>
+            <_ExperimentalFilters.ConfirmButton>
+              Save
+            </_ExperimentalFilters.ConfirmButton>
+          </Box>
+        </_ExperimentalFilters.Footer>
+      </_ExperimentalFilters>
+    </Template>
   );
 };
 
 export const Loading = () => {
   return (
-    <Popover>
-      <Popover.Trigger>
-        <Button>Show filters</Button>
-      </Popover.Trigger>
-      <Popover.Content align="start">
-        <Box
-          __minHeight="250px"
-          __minWidth="636px"
-          display="grid"
-          __gridTemplateRows="auto 1fr"
-        >
-          <Box {...commonHeaderProps}>
-            <Text variant="body" size="medium">
-              Conditions
-            </Text>
-            <Box display="flex" alignItems="center" gap={2}>
-              <Popover.Close>
-                <Button variant="tertiary" icon={<CloseIcon />} />
-              </Popover.Close>
-            </Box>
-          </Box>
-          <Box {...commonFilterProps} display="flex" flexDirection="column">
-            <Box display="flex" flexDirection="column" gap={3} height="100%">
-              <Skeleton height={7} />
-              <Skeleton height={7} />
-              <Skeleton height={7} />
-            </Box>
-            <Divider />
-            <Box display="flex" gap={4} justifyContent="space-between">
-              <Skeleton height={7} __width="60px" />
-              <Box display="flex" gap={3}>
-                <Skeleton height={7} __width="60px" />
-                <Skeleton height={7} __width="60px" />
-              </Box>
-            </Box>
-          </Box>
+    <Template display="flex" flexDirection="column">
+      <Box display="flex" flexDirection="column" gap={3} height="100%">
+        <_ExperimentalFilters.Skeleton height={7} />
+        <_ExperimentalFilters.Skeleton height={7} />
+        <_ExperimentalFilters.Skeleton height={7} />
+      </Box>
+      <Divider />
+      <Box display="flex" gap={4} justifyContent="space-between">
+        <_ExperimentalFilters.Skeleton height={7} __width="60px" />
+        <Box display="flex" gap={3}>
+          <_ExperimentalFilters.Skeleton height={7} __width="60px" />
+          <_ExperimentalFilters.Skeleton height={7} __width="60px" />
         </Box>
-      </Popover.Content>
-    </Popover>
+      </Box>
+    </Template>
   );
 };
 
 export const Error = () => {
-  const value = [
-    {
-      value: { value: "price", label: "Price", type: "1" },
-      condition: {
-        options: [
-          {
-            type: "number",
-            label: "is",
-            value: "input-1",
-          } as const,
-        ],
-        selected: {
-          value: "3.13",
-          conditionValue: {
-            type: "number",
-            label: "is",
-            value: "input-1",
-          } as const,
-        },
-      },
-    },
-  ];
-
   return (
-    <Popover>
-      <Popover.Trigger>
-        <Button>Show filters</Button>
-      </Popover.Trigger>
-      <Popover.Content align="start">
-        <Box
-          __minHeight="250px"
-          __minWidth="636px"
-          display="grid"
-          __gridTemplateRows="auto 1fr"
-        >
-          <Box {...commonHeaderProps}>
-            <Text variant="body" size="medium">
-              Conditions
-            </Text>
-            <Box display="flex" alignItems="center" gap={2}>
-              <Popover.Close>
-                <Button variant="tertiary" icon={<CloseIcon />} />
-              </Popover.Close>
-            </Box>
+    <Template>
+      <_ExperimentalFilters
+        value={defaultValue}
+        error={{
+          row: 0,
+          rightText: "Some error here",
+          leftText: "Some error here",
+        }}
+        leftOptions={[]}
+      >
+        <_ExperimentalFilters.Footer>
+          <_ExperimentalFilters.AddRowButton>
+            Add row
+          </_ExperimentalFilters.AddRowButton>
+          <Box display="flex" gap={3}>
+            <_ExperimentalFilters.ClearButton>
+              Clear
+            </_ExperimentalFilters.ClearButton>
+            <_ExperimentalFilters.ConfirmButton>
+              Save
+            </_ExperimentalFilters.ConfirmButton>
           </Box>
-          <Box {...commonFilterProps}>
-            <_ExperimentalFilters
-              value={value}
-              error={{
-                row: 0,
-                rightText: "Some error here",
-                leftText: "Some error here",
-              }}
-              leftOptions={[]}
-            >
-              <_ExperimentalFilters.Footer>
-                <_ExperimentalFilters.AddRowButton>
-                  Add row
-                </_ExperimentalFilters.AddRowButton>
-                <Box display="flex" gap={3}>
-                  <_ExperimentalFilters.ClearButton>
-                    Clear
-                  </_ExperimentalFilters.ClearButton>
-                  <_ExperimentalFilters.ConfirmButton onClick={() => ({})}>
-                    Save
-                  </_ExperimentalFilters.ConfirmButton>
-                </Box>
-              </_ExperimentalFilters.Footer>
-            </_ExperimentalFilters>
-          </Box>
-        </Box>
-      </Popover.Content>
-    </Popover>
+        </_ExperimentalFilters.Footer>
+      </_ExperimentalFilters>
+    </Template>
   );
 };
 
@@ -399,7 +338,7 @@ export const Constraint = () => {
             type: "number",
             label: "is",
             value: "input-1",
-          } as const,
+          },
         ],
         selected: {
           value: "3.13",
@@ -407,7 +346,7 @@ export const Constraint = () => {
             type: "number",
             label: "is",
             value: "input-1",
-          } as const,
+          },
         },
       },
     },
@@ -431,49 +370,25 @@ export const Constraint = () => {
         },
       },
     },
-  ];
+  ] as Array<Row | string>;
 
   return (
-    <Popover>
-      <Popover.Trigger>
-        <Button>Show filters</Button>
-      </Popover.Trigger>
-      <Popover.Content align="start">
-        <Box
-          __minHeight="250px"
-          __minWidth="636px"
-          display="grid"
-          __gridTemplateRows="auto 1fr"
-        >
-          <Box {...commonHeaderProps}>
-            <Text variant="body" size="medium">
-              Conditions
-            </Text>
-            <Box display="flex" alignItems="center" gap={2}>
-              <Popover.Close>
-                <Button variant="tertiary" icon={<CloseIcon />} />
-              </Popover.Close>
-            </Box>
+    <Template>
+      <_ExperimentalFilters value={value} leftOptions={leftOptions}>
+        <_ExperimentalFilters.Footer>
+          <_ExperimentalFilters.AddRowButton>
+            Add row
+          </_ExperimentalFilters.AddRowButton>
+          <Box display="flex" gap={3}>
+            <_ExperimentalFilters.ClearButton>
+              Clear
+            </_ExperimentalFilters.ClearButton>
+            <_ExperimentalFilters.ConfirmButton>
+              Save
+            </_ExperimentalFilters.ConfirmButton>
           </Box>
-          <Box {...commonFilterProps}>
-            <_ExperimentalFilters value={value} leftOptions={[]}>
-              <_ExperimentalFilters.Footer>
-                <_ExperimentalFilters.AddRowButton>
-                  Add row
-                </_ExperimentalFilters.AddRowButton>
-                <Box display="flex" gap={3}>
-                  <_ExperimentalFilters.ClearButton>
-                    Clear
-                  </_ExperimentalFilters.ClearButton>
-                  <_ExperimentalFilters.ConfirmButton onClick={() => ({})}>
-                    Save
-                  </_ExperimentalFilters.ConfirmButton>
-                </Box>
-              </_ExperimentalFilters.Footer>
-            </_ExperimentalFilters>
-          </Box>
-        </Box>
-      </Popover.Content>
-    </Popover>
+        </_ExperimentalFilters.Footer>
+      </_ExperimentalFilters>
+    </Template>
   );
 };

--- a/src/components/ExperimentalFilters/ExperimentalFilters.stories.tsx
+++ b/src/components/ExperimentalFilters/ExperimentalFilters.stories.tsx
@@ -225,6 +225,7 @@ export const Default = () => {
           if (event?.type === "row.add") {
             const newState = [
               ...rows,
+              "AND",
               {
                 value: null,
                 condition: {

--- a/src/components/ExperimentalFilters/ExperimentalFilters.stories.tsx
+++ b/src/components/ExperimentalFilters/ExperimentalFilters.stories.tsx
@@ -231,7 +231,7 @@ const Filters = () => {
   );
 };
 
-export const WithItems = () => {
+export const Default = () => {
   return (
     <Popover>
       <Popover.Trigger>
@@ -307,46 +307,79 @@ export const Loading = () => {
   );
 };
 
-// export const Loading = () => {
-//   return (
-//     <Popover>
-//       <Popover.Trigger>
-//         <Button>Show filters</Button>
-//       </Popover.Trigger>
-//       <Popover.Content align="start">
-//         <Box
-//           __minHeight="250px"
-//           __minWidth="636px"
-//           display="grid"
-//           __gridTemplateRows="auto 1fr"
-//         >
-//           <Box {...commonHeaderProps}>
-//             <Text variant="body" size="medium">
-//               Filter conditions
-//             </Text>
-//             <Box display="flex" alignItems="center" gap={2}>
-//               <Popover.Close>
-//                 <Button variant="tertiary" icon={<CloseIcon />} />
-//               </Popover.Close>
-//             </Box>
-//           </Box>
-//           <Box
-//             {...commonFilterProps}
-//             display="flex"
-//             gap={3}
-//             flexDirection="column"
-//           >
-//             <Skeleton height={7} />
-//             <Skeleton height={7} />
-//             <Skeleton height={7} />
-//             <Divider />
-//             <Box display="flex" gap={4} justifyContent="space-between">
-//               <Skeleton height={7} __width="20%" />
-//               <Skeleton height={7} __width="20%" />
-//             </Box>
-//           </Box>
-//         </Box>
-//       </Popover.Content>
-//     </Popover>
-//   );
-// };
+export const Error = () => {
+  const value = [
+    {
+      value: { value: "price", label: "Price", type: "1" },
+      condition: {
+        options: [
+          {
+            type: "number",
+            label: "is",
+            value: "input-1",
+          } as const,
+        ],
+        selected: {
+          value: "3.13",
+          conditionValue: {
+            type: "number",
+            label: "is",
+            value: "input-1",
+          } as const,
+        },
+      },
+    },
+  ];
+
+  return (
+    <Popover>
+      <Popover.Trigger>
+        <Button>Show filters</Button>
+      </Popover.Trigger>
+      <Popover.Content align="start">
+        <Box
+          __minHeight="250px"
+          __minWidth="636px"
+          display="grid"
+          __gridTemplateRows="auto 1fr"
+        >
+          <Box {...commonHeaderProps}>
+            <Text variant="body" size="medium">
+              Conditions
+            </Text>
+            <Box display="flex" alignItems="center" gap={2}>
+              <Popover.Close>
+                <Button variant="tertiary" icon={<CloseIcon />} />
+              </Popover.Close>
+            </Box>
+          </Box>
+          <Box {...commonFilterProps}>
+            <_ExperimentalFilters
+              value={value}
+              error={{
+                row: 0,
+                rightText: "Some error here",
+                leftText: "Some error here",
+              }}
+              leftOptions={[]}
+            >
+              <_ExperimentalFilters.Footer>
+                <_ExperimentalFilters.AddRowButton>
+                  Add row
+                </_ExperimentalFilters.AddRowButton>
+                <Box display="flex" gap={3}>
+                  <_ExperimentalFilters.ClearButton>
+                    Clear
+                  </_ExperimentalFilters.ClearButton>
+                  <_ExperimentalFilters.ConfirmButton onClick={() => ({})}>
+                    Save
+                  </_ExperimentalFilters.ConfirmButton>
+                </Box>
+              </_ExperimentalFilters.Footer>
+            </_ExperimentalFilters>
+          </Box>
+        </Box>
+      </Popover.Content>
+    </Popover>
+  );
+};

--- a/src/components/ExperimentalFilters/ExperimentalFilters.stories.tsx
+++ b/src/components/ExperimentalFilters/ExperimentalFilters.stories.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 
 import { Box, Text, Button, Popover, CloseIcon, Divider } from "..";
 import { Skeleton } from "./Skeleton";
-import { Row, _ExperimentalFilters } from ".";
+import { RowComponent, _ExperimentalFilters } from ".";
 
 const meta: Meta<typeof _ExperimentalFilters> = {
   title: "Components / _ExperimentalFilters",
@@ -363,6 +363,100 @@ export const Error = () => {
               }}
               leftOptions={[]}
             >
+              <_ExperimentalFilters.Footer>
+                <_ExperimentalFilters.AddRowButton>
+                  Add row
+                </_ExperimentalFilters.AddRowButton>
+                <Box display="flex" gap={3}>
+                  <_ExperimentalFilters.ClearButton>
+                    Clear
+                  </_ExperimentalFilters.ClearButton>
+                  <_ExperimentalFilters.ConfirmButton onClick={() => ({})}>
+                    Save
+                  </_ExperimentalFilters.ConfirmButton>
+                </Box>
+              </_ExperimentalFilters.Footer>
+            </_ExperimentalFilters>
+          </Box>
+        </Box>
+      </Popover.Content>
+    </Popover>
+  );
+};
+
+export const Constraint = () => {
+  const value = [
+    {
+      value: { value: "price", label: "Price", type: "1" },
+      constraint: {
+        dependsOn: "category",
+        disabled: ["left", "condition"],
+        removable: false,
+      },
+      condition: {
+        options: [
+          {
+            type: "number",
+            label: "is",
+            value: "input-1",
+          } as const,
+        ],
+        selected: {
+          value: "3.13",
+          conditionValue: {
+            type: "number",
+            label: "is",
+            value: "input-1",
+          } as const,
+        },
+      },
+    },
+    "AND",
+    {
+      value: { value: "category", label: "Categories", type: "2" },
+      condition: {
+        options: [{ value: "input-1", label: "are", type: "multiselect" }],
+        selected: {
+          conditionValue: {
+            value: "input-1",
+            label: "are",
+            type: "multiselect",
+          },
+          value: [],
+          options: [
+            { value: "electronics", label: "Electronics" },
+            { value: "clothing", label: "Clothing" },
+            { value: "furniture", label: "Furniture" },
+          ],
+        },
+      },
+    },
+  ];
+
+  return (
+    <Popover>
+      <Popover.Trigger>
+        <Button>Show filters</Button>
+      </Popover.Trigger>
+      <Popover.Content align="start">
+        <Box
+          __minHeight="250px"
+          __minWidth="636px"
+          display="grid"
+          __gridTemplateRows="auto 1fr"
+        >
+          <Box {...commonHeaderProps}>
+            <Text variant="body" size="medium">
+              Conditions
+            </Text>
+            <Box display="flex" alignItems="center" gap={2}>
+              <Popover.Close>
+                <Button variant="tertiary" icon={<CloseIcon />} />
+              </Popover.Close>
+            </Box>
+          </Box>
+          <Box {...commonFilterProps}>
+            <_ExperimentalFilters value={value} leftOptions={[]}>
               <_ExperimentalFilters.Footer>
                 <_ExperimentalFilters.AddRowButton>
                   Add row

--- a/src/components/ExperimentalFilters/ExperimentalFilters.stories.tsx
+++ b/src/components/ExperimentalFilters/ExperimentalFilters.stories.tsx
@@ -327,11 +327,6 @@ export const Constraint = () => {
   const value = [
     {
       value: { value: "price", label: "Price", type: "1" },
-      constraint: {
-        dependsOn: "category",
-        disabled: ["left", "condition"],
-        removable: false,
-      },
       condition: {
         options: [
           {
@@ -353,6 +348,11 @@ export const Constraint = () => {
     "AND",
     {
       value: { value: "category", label: "Categories", type: "2" },
+      constraint: {
+        dependsOn: ["price"],
+        disabled: ["left", "condition", "right"],
+        removable: false,
+      },
       condition: {
         options: [{ value: "input-1", label: "are", type: "multiselect" }],
         selected: {
@@ -361,7 +361,7 @@ export const Constraint = () => {
             label: "are",
             type: "multiselect",
           },
-          value: [],
+          value: [{ value: "electronics", label: "Electronics" }],
           options: [
             { value: "electronics", label: "Electronics" },
             { value: "clothing", label: "Clothing" },

--- a/src/components/ExperimentalFilters/Filters.tsx
+++ b/src/components/ExperimentalFilters/Filters.tsx
@@ -3,7 +3,6 @@ import { Box, Text } from "..";
 import { RowComponent } from "./Row";
 import { FilterEventEmitter } from "./EventEmitter";
 
-import { extractConstrains, getRowConstraint } from "./constrains";
 import { ExperimentalFiltersProps } from ".";
 
 type FiltersProps = Pick<
@@ -21,8 +20,6 @@ export const Filters = ({
   locale,
   error,
 }: FiltersProps) => {
-  const constrains = extractConstrains(value);
-
   return (
     <Box
       display="grid"
@@ -46,7 +43,6 @@ export const Filters = ({
             leftOptions={leftOptions}
             emitter={emitter}
             error={error?.row === idx ? error : undefined}
-            constrain={getRowConstraint(constrains, item.value?.value)}
           />
         )
       )}

--- a/src/components/ExperimentalFilters/Filters.tsx
+++ b/src/components/ExperimentalFilters/Filters.tsx
@@ -1,8 +1,9 @@
 import { Box, Text } from "..";
 
-import { Row } from "./Row";
+import { RowComponent } from "./Row";
 import { FilterEventEmitter } from "./EventEmitter";
 
+import { extractConstrains, getRowConstraint } from "./constrains";
 import { ExperimentalFiltersProps } from ".";
 
 type FiltersProps = Pick<
@@ -19,31 +20,36 @@ export const Filters = ({
   emitter,
   locale,
   error,
-}: FiltersProps) => (
-  <Box
-    display="grid"
-    __gridTemplateColumns="repeat(2, auto)"
-    alignItems="start"
-    columnGap={2}
-    rowGap={3}
-    alignSelf="start"
-  >
-    <Text paddingTop={1.5}>{locale.WHERE}</Text>
-    {value.map((item, idx) =>
-      typeof item === "string" ? (
-        <Text key={idx} paddingTop={1.5}>
-          {locale[item]}
-        </Text>
-      ) : (
-        <Row
-          item={item}
-          index={idx}
-          key={`filterRow-${idx}`}
-          leftOptions={leftOptions}
-          emitter={emitter}
-          error={error?.row === idx ? error : undefined}
-        />
-      )
-    )}
-  </Box>
-);
+}: FiltersProps) => {
+  const constrains = extractConstrains(value);
+
+  return (
+    <Box
+      display="grid"
+      __gridTemplateColumns="repeat(2, auto)"
+      alignItems="start"
+      columnGap={2}
+      rowGap={3}
+      alignSelf="start"
+    >
+      <Text paddingTop={1.5}>{locale.WHERE}</Text>
+      {value.map((item, idx) =>
+        typeof item === "string" ? (
+          <Text key={idx} paddingTop={1.5}>
+            {locale[item]}
+          </Text>
+        ) : (
+          <RowComponent
+            item={item}
+            index={idx}
+            key={`filterRow-${idx}`}
+            leftOptions={leftOptions}
+            emitter={emitter}
+            error={error?.row === idx ? error : undefined}
+            constrain={getRowConstraint(constrains, item.value?.value)}
+          />
+        )
+      )}
+    </Box>
+  );
+};

--- a/src/components/ExperimentalFilters/Filters.tsx
+++ b/src/components/ExperimentalFilters/Filters.tsx
@@ -5,7 +5,10 @@ import { FilterEventEmitter } from "./EventEmitter";
 
 import { ExperimentalFiltersProps } from ".";
 
-type FiltersProps = Pick<ExperimentalFiltersProps, "value" | "leftOptions"> & {
+type FiltersProps = Pick<
+  ExperimentalFiltersProps,
+  "value" | "leftOptions" | "error"
+> & {
   emitter: FilterEventEmitter;
   locale: Record<string, string>;
 };
@@ -15,19 +18,22 @@ export const Filters = ({
   leftOptions,
   emitter,
   locale,
+  error,
 }: FiltersProps) => (
   <Box
     display="grid"
     __gridTemplateColumns="repeat(2, auto)"
-    alignItems="center"
+    alignItems="start"
     columnGap={2}
     rowGap={3}
     alignSelf="start"
   >
-    <Text>{locale.WHERE}</Text>
+    <Text paddingTop={1.5}>{locale.WHERE}</Text>
     {value.map((item, idx) =>
       typeof item === "string" ? (
-        <Text key={idx}>{locale[item]}</Text>
+        <Text key={idx} paddingTop={1.5}>
+          {locale[item]}
+        </Text>
       ) : (
         <Row
           item={item}
@@ -35,6 +41,7 @@ export const Filters = ({
           key={`filterRow-${idx}`}
           leftOptions={leftOptions}
           emitter={emitter}
+          error={error?.row === idx ? error : undefined}
         />
       )
     )}

--- a/src/components/ExperimentalFilters/RightOperator.tsx
+++ b/src/components/ExperimentalFilters/RightOperator.tsx
@@ -10,6 +10,7 @@ type RightOperatorProps = {
   index: number;
   selected: SelectedOperator;
   emitter: FilterEventEmitter;
+  error?: string;
 };
 
 export type SelectedOperator =
@@ -89,6 +90,7 @@ export const RightOperator = ({
   index,
   selected,
   emitter,
+  error,
 }: RightOperatorProps) => {
   if (isTextInput(selected)) {
     return (
@@ -103,6 +105,8 @@ export const RightOperator = ({
         onBlur={() => {
           emitter.blurRightOperator(index);
         }}
+        error={!!error}
+        helperText={error}
       />
     );
   }
@@ -121,6 +125,8 @@ export const RightOperator = ({
         onBlur={() => {
           emitter.blurRightOperator(index);
         }}
+        error={!!error}
+        helperText={error}
       />
     );
   }
@@ -141,6 +147,8 @@ export const RightOperator = ({
         onBlur={() => {
           emitter.blurRightOperator(index);
         }}
+        error={!!error}
+        helperText={error}
       />
     );
   }
@@ -161,6 +169,8 @@ export const RightOperator = ({
         onBlur={() => {
           emitter.blurRightOperator(index);
         }}
+        error={!!error}
+        helperText={error}
       />
     );
   }
@@ -177,6 +187,8 @@ export const RightOperator = ({
         onBlur={() => {
           emitter.blurRightOperator(index);
         }}
+        error={!!error}
+        helperText={error}
       />
     );
   }
@@ -192,6 +204,8 @@ export const RightOperator = ({
           onChange={(e) => {
             emitter.changeRightOperator(index, [e.target.value, end]);
           }}
+          error={!!error}
+          helperText={error}
         />
         <Box>-</Box>
         <Input
@@ -200,6 +214,8 @@ export const RightOperator = ({
           onChange={(e) => {
             emitter.changeRightOperator(index, [start, e.target.value]);
           }}
+          error={!!error}
+          helperText={error}
         />
       </Box>
     );
@@ -213,6 +229,8 @@ export const RightOperator = ({
         onChange={(e) => {
           emitter.changeRightOperator(index, e.target.value);
         }}
+        error={!!error}
+        helperText={error}
       />
     );
   }
@@ -225,6 +243,8 @@ export const RightOperator = ({
         onChange={(e) => {
           emitter.changeRightOperator(index, e.target.value);
         }}
+        error={!!error}
+        helperText={error}
       />
     );
   }

--- a/src/components/ExperimentalFilters/RightOperator.tsx
+++ b/src/components/ExperimentalFilters/RightOperator.tsx
@@ -18,7 +18,7 @@ type RightOperatorProps = {
   selected: SelectedOperator;
   emitter: FilterEventEmitter;
   error?: string;
-  disabled?: boolean;
+  disabled: boolean;
 };
 
 export const RightOperator = ({

--- a/src/components/ExperimentalFilters/RightOperator.tsx
+++ b/src/components/ExperimentalFilters/RightOperator.tsx
@@ -11,6 +11,7 @@ type RightOperatorProps = {
   selected: SelectedOperator;
   emitter: FilterEventEmitter;
   error?: string;
+  disabled?: boolean;
 };
 
 export type SelectedOperator =
@@ -91,6 +92,7 @@ export const RightOperator = ({
   selected,
   emitter,
   error,
+  disabled,
 }: RightOperatorProps) => {
   if (isTextInput(selected)) {
     return (
@@ -107,6 +109,7 @@ export const RightOperator = ({
         }}
         error={!!error}
         helperText={error}
+        disabled={disabled}
       />
     );
   }
@@ -127,6 +130,7 @@ export const RightOperator = ({
         }}
         error={!!error}
         helperText={error}
+        disabled={disabled}
       />
     );
   }
@@ -149,6 +153,7 @@ export const RightOperator = ({
         }}
         error={!!error}
         helperText={error}
+        disabled={disabled}
       />
     );
   }
@@ -171,6 +176,7 @@ export const RightOperator = ({
         }}
         error={!!error}
         helperText={error}
+        disabled={disabled}
       />
     );
   }
@@ -189,6 +195,7 @@ export const RightOperator = ({
         }}
         error={!!error}
         helperText={error}
+        disabled
       />
     );
   }
@@ -206,6 +213,7 @@ export const RightOperator = ({
           }}
           error={!!error}
           helperText={error}
+          disabled={disabled}
         />
         <Box>-</Box>
         <Input
@@ -216,6 +224,7 @@ export const RightOperator = ({
           }}
           error={!!error}
           helperText={error}
+          disabled={disabled}
         />
       </Box>
     );
@@ -231,6 +240,7 @@ export const RightOperator = ({
         }}
         error={!!error}
         helperText={error}
+        disabled={disabled}
       />
     );
   }
@@ -245,6 +255,7 @@ export const RightOperator = ({
         }}
         error={!!error}
         helperText={error}
+        disabled={disabled}
       />
     );
   }

--- a/src/components/ExperimentalFilters/RightOperator.tsx
+++ b/src/components/ExperimentalFilters/RightOperator.tsx
@@ -1,10 +1,17 @@
 import { Box, DynamicCombobox, Input, DynamicMultiselect, Select } from "..";
 
+import { FilterEventEmitter } from "./EventEmitter";
+import { SelectedOperator } from "./types";
 import {
-  ConditionOption,
-  FilterEventEmitter,
-  RightOperatorOption,
-} from "./EventEmitter";
+  isCombobox,
+  isDate,
+  isDateTime,
+  isMultiselect,
+  isNumberInput,
+  isNumberRange,
+  isSelect,
+  isTextInput,
+} from "./utils";
 
 type RightOperatorProps = {
   index: number;
@@ -13,79 +20,6 @@ type RightOperatorProps = {
   error?: string;
   disabled?: boolean;
 };
-
-export type SelectedOperator =
-  | InputOperator
-  | MultiselectOperator
-  | ComboboxOperator
-  | SelectOperator
-  | NumberRangeOperator
-  | DateOperator
-  | DateTimeOperator;
-
-type InputOperator = {
-  value: string;
-  conditionValue: ConditionOption<"text" | "number"> | null;
-};
-
-type MultiselectOperator = {
-  value: RightOperatorOption[];
-  conditionValue: ConditionOption<"multiselect"> | null;
-  options: Array<RightOperatorOption>;
-  loading?: boolean;
-};
-
-type ComboboxOperator = {
-  value: RightOperatorOption;
-  conditionValue: ConditionOption<"combobox"> | null;
-  options: Array<RightOperatorOption>;
-  loading?: boolean;
-};
-
-type SelectOperator = {
-  value: RightOperatorOption;
-  conditionValue: ConditionOption<"select"> | null;
-  options: Array<RightOperatorOption>;
-};
-
-type NumberRangeOperator = {
-  value: [string, string];
-  conditionValue: ConditionOption<"number.range"> | null;
-};
-
-type DateOperator = {
-  value: string;
-  conditionValue: ConditionOption<"date"> | null;
-};
-
-type DateTimeOperator = {
-  value: string;
-  conditionValue: ConditionOption<"datetime"> | null;
-};
-
-const isTextInput = (value: SelectedOperator): value is InputOperator =>
-  value.conditionValue?.type === "text";
-
-const isNumberInput = (value: SelectedOperator): value is InputOperator =>
-  value.conditionValue?.type === "number";
-
-const isMultiselect = (value: SelectedOperator): value is MultiselectOperator =>
-  value.conditionValue?.type === "multiselect";
-
-const isCombobox = (value: SelectedOperator): value is ComboboxOperator =>
-  value.conditionValue?.type === "combobox";
-
-const isSelect = (value: SelectedOperator): value is SelectOperator =>
-  value.conditionValue?.type === "select";
-
-const isNumberRange = (value: SelectedOperator): value is NumberRangeOperator =>
-  value.conditionValue?.type === "number.range";
-
-const isDate = (value: SelectedOperator): value is DateOperator =>
-  value.conditionValue?.type === "date";
-
-const isDateTime = (value: SelectedOperator): value is DateTimeOperator =>
-  value.conditionValue?.type === "datetime";
 
 export const RightOperator = ({
   index,
@@ -195,7 +129,7 @@ export const RightOperator = ({
         }}
         error={!!error}
         helperText={error}
-        disabled
+        disabled={disabled}
       />
     );
   }

--- a/src/components/ExperimentalFilters/Root.tsx
+++ b/src/components/ExperimentalFilters/Root.tsx
@@ -3,7 +3,7 @@ import { Box, Divider } from "..";
 
 import { FilterContext } from "./context";
 import { useEventEmitter } from "./useEvents";
-import type { FilterEvent, LeftOperatorOption, Row } from "./types";
+import type { FilterEvent, LeftOperatorOption, Row, Error } from "./types";
 import { Filters } from "./Filters";
 import { NoValue } from "./NoValue";
 
@@ -13,12 +13,7 @@ export type ExperimentalFiltersProps = {
   children?: ReactNode;
   onChange?: (event: FilterEvent["detail"]) => void;
   locale?: Record<string, string>;
-  error?: {
-    row: number;
-    leftText?: string;
-    conditionText?: string;
-    rightText?: string;
-  };
+  error?: Error;
 };
 
 export const Root = ({

--- a/src/components/ExperimentalFilters/Root.tsx
+++ b/src/components/ExperimentalFilters/Root.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from "react";
-import { Box, Divider, Text } from "..";
+import { Box, Divider } from "..";
 
 import { FilterContext } from "./context";
 import { FilterEvent, useEventEmitter } from "./useEvents";
@@ -14,6 +14,12 @@ export type ExperimentalFiltersProps = {
   children?: ReactNode;
   onChange?: (event: FilterEvent["detail"]) => void;
   locale?: Record<string, string>;
+  error?: {
+    row: number;
+    leftText?: string;
+    conditionText?: string;
+    rightText?: string;
+  };
 };
 
 export const Root = ({
@@ -27,6 +33,7 @@ export const Root = ({
     OR: "or",
     noValueText: "Click button below to start filtering",
   },
+  error,
 }: ExperimentalFiltersProps) => {
   const { emitter } = useEventEmitter({
     onChange,
@@ -43,6 +50,7 @@ export const Root = ({
             leftOptions={leftOptions}
             emitter={emitter}
             locale={locale}
+            error={error}
           />
         ) : (
           <NoValue locale={locale} />

--- a/src/components/ExperimentalFilters/Root.tsx
+++ b/src/components/ExperimentalFilters/Root.tsx
@@ -2,9 +2,8 @@ import { ReactNode } from "react";
 import { Box, Divider } from "..";
 
 import { FilterContext } from "./context";
-import { FilterEvent, useEventEmitter } from "./useEvents";
-import type { Row } from "./Row";
-import { LeftOperatorOption } from "./EventEmitter";
+import { useEventEmitter } from "./useEvents";
+import type { FilterEvent, LeftOperatorOption, Row } from "./types";
 import { Filters } from "./Filters";
 import { NoValue } from "./NoValue";
 

--- a/src/components/ExperimentalFilters/Root.tsx
+++ b/src/components/ExperimentalFilters/Root.tsx
@@ -3,7 +3,7 @@ import { Box, Divider } from "..";
 
 import { FilterContext } from "./context";
 import { FilterEvent, useEventEmitter } from "./useEvents";
-import { Row } from "./Row";
+import type { Row } from "./Row";
 import { LeftOperatorOption } from "./EventEmitter";
 import { Filters } from "./Filters";
 import { NoValue } from "./NoValue";

--- a/src/components/ExperimentalFilters/Row.tsx
+++ b/src/components/ExperimentalFilters/Row.tsx
@@ -1,36 +1,10 @@
 import { DynamicCombobox, Box, Select, Button, RemoveIcon } from "..";
 
-import { ConditionOption, FilterEventEmitter } from "./EventEmitter";
+import { FilterEventEmitter } from "./EventEmitter";
 import { ExperimentalFiltersProps } from "./Root";
-import { RightOperator, SelectedOperator } from "./RightOperator";
+import { RightOperator } from "./RightOperator";
 import { InternalConstrain } from "./constrains";
-
-type DisabledScope = "left" | "right" | "condition";
-
-export type Row = {
-  value: { label: string; value: string; type: string } | null;
-  loading?: boolean;
-  constraint?: {
-    dependsOn: string;
-    disabled?: DisabledScope[];
-    removable?: boolean;
-  };
-  condition: {
-    loading?: boolean;
-    options: Array<
-      ConditionOption<
-        | "text"
-        | "number"
-        | "multiselect"
-        | "combobox"
-        | "select"
-        | "number.range"
-        | "date"
-      >
-    >;
-    selected: SelectedOperator;
-  };
-};
+import { Row } from "./types";
 
 type RowProps = {
   item: Row;

--- a/src/components/ExperimentalFilters/Row.tsx
+++ b/src/components/ExperimentalFilters/Row.tsx
@@ -9,6 +9,12 @@ type RowProps = {
   index: number;
   leftOptions: ExperimentalFiltersProps["leftOptions"];
   emitter: FilterEventEmitter;
+  error?: {
+    row: number;
+    leftText?: string;
+    conditionText?: string;
+    rightText?: string;
+  };
 };
 
 export type Row = {
@@ -31,13 +37,14 @@ export type Row = {
   };
 };
 
-export const Row = ({ item, index, leftOptions, emitter }: RowProps) => {
+export const Row = ({ item, index, leftOptions, emitter, error }: RowProps) => {
   return (
     <Box
       display="grid"
       gap={0.5}
       __gridTemplateColumns="200px 120px 200px auto"
       placeItems="center"
+      alignItems="start"
     >
       <DynamicCombobox
         value={item.value}
@@ -60,6 +67,8 @@ export const Row = ({ item, index, leftOptions, emitter }: RowProps) => {
         onBlur={() => {
           emitter.blurLeftOperator(index);
         }}
+        error={!!error?.leftText}
+        helperText={error?.leftText}
       />
       <Select
         value={item.condition.selected.conditionValue}
@@ -74,6 +83,8 @@ export const Row = ({ item, index, leftOptions, emitter }: RowProps) => {
         onBlur={() => {
           emitter.blurCondition(index);
         }}
+        error={!!error?.conditionText}
+        helperText={error?.conditionText}
       />
 
       {item.condition?.selected && (
@@ -81,6 +92,7 @@ export const Row = ({ item, index, leftOptions, emitter }: RowProps) => {
           selected={item.condition?.selected}
           index={index}
           emitter={emitter}
+          error={error?.rightText}
         />
       )}
 

--- a/src/components/ExperimentalFilters/Row.tsx
+++ b/src/components/ExperimentalFilters/Row.tsx
@@ -55,6 +55,7 @@ export const RowComponent = ({
         helperText={error?.leftText}
         disabled={constrain.disableLeftOperator}
       />
+
       <Select
         value={item.condition.selected.conditionValue}
         options={item.condition.options}
@@ -72,15 +73,13 @@ export const RowComponent = ({
         helperText={error?.conditionText}
       />
 
-      {item.condition?.selected && (
-        <RightOperator
-          selected={item.condition?.selected}
-          index={index}
-          emitter={emitter}
-          error={error?.rightText}
-          disabled={constrain.disableRightOperator}
-        />
-      )}
+      <RightOperator
+        selected={item.condition?.selected}
+        index={index}
+        emitter={emitter}
+        error={error?.rightText}
+        disabled={constrain.disableRightOperator}
+      />
 
       <Button
         variant="tertiary"

--- a/src/components/ExperimentalFilters/Row.tsx
+++ b/src/components/ExperimentalFilters/Row.tsx
@@ -3,7 +3,7 @@ import { DynamicCombobox, Box, Select, Button, RemoveIcon } from "..";
 import { FilterEventEmitter } from "./EventEmitter";
 import { ExperimentalFiltersProps } from "./Root";
 import { RightOperator } from "./RightOperator";
-import { InternalConstrain } from "./constrains";
+import { getItemConstraint } from "./constrains";
 import { Row } from "./types";
 
 type RowProps = {
@@ -11,8 +11,7 @@ type RowProps = {
   index: number;
   leftOptions: ExperimentalFiltersProps["leftOptions"];
   emitter: FilterEventEmitter;
-  error?: ExperimentalFiltersProps["error"];
-  constrain: InternalConstrain;
+  error: ExperimentalFiltersProps["error"];
 };
 
 export const RowComponent = ({
@@ -21,17 +20,14 @@ export const RowComponent = ({
   leftOptions,
   emitter,
   error,
-  constrain,
 }: RowProps) => {
+  const constrain = getItemConstraint(item.constraint);
+
   return (
     <Box
       display="grid"
       gap={0.5}
-      __gridTemplateColumns={
-        constrain.showRemoveButton
-          ? "200px 120px 200px auto"
-          : "200px 120px 1fr"
-      }
+      __gridTemplateColumns="200px 120px 200px auto"
       placeItems="center"
       alignItems="start"
     >
@@ -43,8 +39,7 @@ export const RowComponent = ({
           emitter.changeLeftOperator(
             index,
             value,
-            leftOptions.find((option) => option.value === value.value)?.type ??
-              "any"
+            leftOptions.find((option) => option.value === value.value)?.type
           );
         }}
         onInputValueChange={(value) => {
@@ -58,12 +53,12 @@ export const RowComponent = ({
         }}
         error={!!error?.leftText}
         helperText={error?.leftText}
-        disabled={constrain?.disableLeftOperator}
+        disabled={constrain.disableLeftOperator}
       />
       <Select
         value={item.condition.selected.conditionValue}
         options={item.condition.options}
-        disabled={constrain?.disableCondition}
+        disabled={constrain.disableCondition}
         onChange={(value) => {
           emitter.changeCondition(index, value);
         }}
@@ -83,17 +78,16 @@ export const RowComponent = ({
           index={index}
           emitter={emitter}
           error={error?.rightText}
-          disabled={constrain?.disableRightOperator}
+          disabled={constrain.disableRightOperator}
         />
       )}
 
-      {constrain.showRemoveButton && (
-        <Button
-          variant="tertiary"
-          icon={<RemoveIcon />}
-          onClick={() => emitter.removeRow(index)}
-        />
-      )}
+      <Button
+        variant="tertiary"
+        icon={<RemoveIcon />}
+        onClick={() => emitter.removeRow(index)}
+        disabled={constrain.disableRemoveButton}
+      />
     </Box>
   );
 };

--- a/src/components/ExperimentalFilters/constrains.ts
+++ b/src/components/ExperimentalFilters/constrains.ts
@@ -1,4 +1,4 @@
-import { Row } from "./Row";
+import { Row } from "./types";
 
 export type InternalConstrain = {
   showRemoveButton?: boolean;

--- a/src/components/ExperimentalFilters/constrains.ts
+++ b/src/components/ExperimentalFilters/constrains.ts
@@ -1,44 +1,8 @@
 import { Row } from "./types";
 
-export type InternalConstrain = {
-  showRemoveButton?: boolean;
-  disableLeftOperator?: boolean;
-  disableCondition?: boolean;
-  disableRightOperator?: boolean;
-};
-
-export const extractConstrains = (
-  value: Array<Row | string>
-): Record<string, InternalConstrain> =>
-  value
-    .filter((item): item is Row => typeof item !== "string")
-    .filter((item) => item.constraint)
-    .map((item) => item.constraint)
-    .reduce(
-      (acc, item) => ({
-        ...acc,
-        [item?.dependsOn ?? ""]: {
-          showRemoveButton: item?.removable,
-          disableLeftOperator: item?.disabled?.includes("left"),
-          disableCondition: item?.disabled?.includes("condition"),
-          disableRightOperator: item?.disabled?.includes("right"),
-        },
-      }),
-      {}
-    );
-
-export const getRowConstraint = (
-  constrains: Record<string, InternalConstrain>,
-  value: string | undefined
-) => {
-  const possibleConstraint = constrains[value ?? ""];
-
-  return (
-    possibleConstraint ?? {
-      showRemoveButton: true,
-      disableLeftOperator: false,
-      disableCondition: false,
-      disableRightOperator: false,
-    }
-  );
-};
+export const getItemConstraint = (constraint: Row["constraint"]) => ({
+  disableRemoveButton: constraint?.removable === false ? true : false,
+  disableLeftOperator: constraint?.disabled?.includes("left") ?? false,
+  disableCondition: constraint?.disabled?.includes("condition") ?? false,
+  disableRightOperator: constraint?.disabled?.includes("right") ?? false,
+});

--- a/src/components/ExperimentalFilters/constrains.ts
+++ b/src/components/ExperimentalFilters/constrains.ts
@@ -1,0 +1,44 @@
+import { Row } from "./Row";
+
+export type InternalConstrain = {
+  showRemoveButton?: boolean;
+  disableLeftOperator?: boolean;
+  disableCondition?: boolean;
+  disableRightOperator?: boolean;
+};
+
+export const extractConstrains = (
+  value: Array<Row | string>
+): Record<string, InternalConstrain> =>
+  value
+    .filter((item): item is Row => typeof item !== "string")
+    .filter((item) => item.constraint)
+    .map((item) => item.constraint)
+    .reduce(
+      (acc, item) => ({
+        ...acc,
+        [item?.dependsOn ?? ""]: {
+          showRemoveButton: item?.removable,
+          disableLeftOperator: item?.disabled?.includes("left"),
+          disableCondition: item?.disabled?.includes("condition"),
+          disableRightOperator: item?.disabled?.includes("right"),
+        },
+      }),
+      {}
+    );
+
+export const getRowConstraint = (
+  constrains: Record<string, InternalConstrain>,
+  value: string | undefined
+) => {
+  const possibleConstraint = constrains[value ?? ""];
+
+  return (
+    possibleConstraint ?? {
+      showRemoveButton: true,
+      disableLeftOperator: false,
+      disableCondition: false,
+      disableRightOperator: false,
+    }
+  );
+};

--- a/src/components/ExperimentalFilters/index.ts
+++ b/src/components/ExperimentalFilters/index.ts
@@ -1,7 +1,7 @@
 export type { FilterEvent } from "./useEvents";
 export type { ExperimentalFiltersProps } from "./Root";
 export type { SelectedOperator } from "./RightOperator";
-export type { Row } from "./Row";
+export type { RowComponent } from "./Row";
 export type {
   RightOperatorOption,
   LeftOperatorOption,

--- a/src/components/ExperimentalFilters/index.ts
+++ b/src/components/ExperimentalFilters/index.ts
@@ -1,5 +1,5 @@
 export type { ExperimentalFiltersProps } from "./Root";
-export type * from "./types";
+export type { Row, FilterEvent } from "./types";
 
 import { Root } from "./Root";
 import { AddRowButton, ConfirmButton, Footer, ClearButton } from "./Footer";

--- a/src/components/ExperimentalFilters/index.ts
+++ b/src/components/ExperimentalFilters/index.ts
@@ -6,6 +6,7 @@ export type {
   RightOperatorOption,
   LeftOperatorOption,
   ConditionOption,
+  Error,
 } from "./types";
 
 import { Root } from "./Root";

--- a/src/components/ExperimentalFilters/index.ts
+++ b/src/components/ExperimentalFilters/index.ts
@@ -1,5 +1,12 @@
 export type { ExperimentalFiltersProps } from "./Root";
-export type { Row, FilterEvent } from "./types";
+export type {
+  Row,
+  FilterEvent,
+  SelectedOperator,
+  RightOperatorOption,
+  LeftOperatorOption,
+  ConditionOption,
+} from "./types";
 
 import { Root } from "./Root";
 import { AddRowButton, ConfirmButton, Footer, ClearButton } from "./Footer";

--- a/src/components/ExperimentalFilters/index.ts
+++ b/src/components/ExperimentalFilters/index.ts
@@ -1,12 +1,5 @@
-export type { FilterEvent } from "./useEvents";
 export type { ExperimentalFiltersProps } from "./Root";
-export type { SelectedOperator } from "./RightOperator";
-export type { RowComponent } from "./Row";
-export type {
-  RightOperatorOption,
-  LeftOperatorOption,
-  ConditionOption,
-} from "./EventEmitter";
+export type * from "./types";
 
 import { Root } from "./Root";
 import { AddRowButton, ConfirmButton, Footer, ClearButton } from "./Footer";

--- a/src/components/ExperimentalFilters/types.ts
+++ b/src/components/ExperimentalFilters/types.ts
@@ -14,11 +14,18 @@ export type ConditionOption<T extends string> = Option & {
   type: T;
 };
 
+export type Error = {
+  row: number;
+  leftText?: string;
+  conditionText?: string;
+  rightText?: string;
+};
+
 export type Row = {
   value: { label: string; value: string; type: string } | null;
   loading?: boolean;
   constraint?: {
-    dependsOn: string;
+    dependsOn: string[];
     disabled?: DisabledScope[];
     removable?: boolean;
   };

--- a/src/components/ExperimentalFilters/types.ts
+++ b/src/components/ExperimentalFilters/types.ts
@@ -1,0 +1,202 @@
+import { Option } from "..";
+
+export type DisabledScope = "left" | "right" | "condition";
+
+export type RightOperatorOption = Option & {
+  slug: string;
+};
+
+export type LeftOperatorOption = Option & {
+  type: string;
+};
+
+export type ConditionOption<T extends string> = Option & {
+  type: T;
+};
+
+export type Row = {
+  value: { label: string; value: string; type: string } | null;
+  loading?: boolean;
+  constraint?: {
+    dependsOn: string;
+    disabled?: DisabledScope[];
+    removable?: boolean;
+  };
+  condition: {
+    loading?: boolean;
+    options: Array<
+      ConditionOption<
+        | "text"
+        | "number"
+        | "multiselect"
+        | "combobox"
+        | "select"
+        | "number.range"
+        | "date"
+      >
+    >;
+    selected: SelectedOperator;
+  };
+};
+
+export type SelectedOperator =
+  | InputOperator
+  | MultiselectOperator
+  | ComboboxOperator
+  | SelectOperator
+  | NumberRangeOperator
+  | DateOperator
+  | DateTimeOperator;
+
+export type InputOperator = {
+  value: string;
+  conditionValue: ConditionOption<"text" | "number"> | null;
+};
+
+export type MultiselectOperator = {
+  value: RightOperatorOption[];
+  conditionValue: ConditionOption<"multiselect"> | null;
+  options: Array<RightOperatorOption>;
+  loading?: boolean;
+};
+
+export type ComboboxOperator = {
+  value: RightOperatorOption;
+  conditionValue: ConditionOption<"combobox"> | null;
+  options: Array<RightOperatorOption>;
+  loading?: boolean;
+};
+
+export type SelectOperator = {
+  value: RightOperatorOption;
+  conditionValue: ConditionOption<"select"> | null;
+  options: Array<RightOperatorOption>;
+};
+
+export type NumberRangeOperator = {
+  value: [string, string];
+  conditionValue: ConditionOption<"number.range"> | null;
+};
+
+export type DateOperator = {
+  value: string;
+  conditionValue: ConditionOption<"date"> | null;
+};
+
+export type DateTimeOperator = {
+  value: string;
+  conditionValue: ConditionOption<"datetime"> | null;
+};
+
+export interface FilterEvent extends Event {
+  detail?:
+    | RowAddData
+    | RowRemoveData
+    | LeftOperatorChangeData
+    | LeftOperatorFocusData
+    | LeftOperatorBlurData
+    | LeftOperatorInputValueChangeData
+    | ConditionChangeData
+    | ConditionFocusData
+    | ConditionBlurData
+    | RightOperatorChangeData
+    | RightOperatorFocusData
+    | RightOperatorBlurData
+    | RightOperatorInputValueChangeData;
+}
+
+export type RowAddData = {
+  type: "row.add";
+  rowType: string;
+};
+
+export type RowRemoveData = {
+  type: "row.remove";
+  path: `${number}`;
+  index: number;
+};
+
+export type LeftOperatorChangeData = {
+  type: "leftOperator.onChange";
+  path: `${number}`;
+  index: number;
+  value: LeftOperatorOption;
+  rowType: string;
+};
+
+export type LeftOperatorFocusData = {
+  type: "leftOperator.onFocus";
+  path: `${number}`;
+  index: number;
+};
+
+export type LeftOperatorBlurData = {
+  type: "leftOperator.onBlur";
+  path: `${number}`;
+  index: number;
+};
+
+export type LeftOperatorInputValueChangeData = {
+  type: "leftOperator.onInputValueChange";
+  path: `${number}`;
+  index: number;
+  value: string;
+};
+
+export type ConditionChangeData = {
+  type: "condition.onChange";
+  path: `${number}.condition.selected`;
+  index: number;
+  value: ConditionOption<
+    | "text"
+    | "number"
+    | "multiselect"
+    | "combobox"
+    | "select"
+    | "number.range"
+    | "date"
+    | "datetime"
+  >;
+};
+
+export type ConditionFocusData = {
+  type: "condition.onFocus";
+  path: `${number}.condition.selected`;
+  index: number;
+};
+
+export type ConditionBlurData = {
+  type: "condition.onBlur";
+  path: `${number}.condition.selected`;
+  index: number;
+};
+
+export type RightOperatorChangeData = {
+  type: "rightOperator.onChange";
+  path: `${number}.condition.selected.value`;
+  index: number;
+  value:
+    | string
+    | RightOperatorOption[]
+    | RightOperatorOption
+    | [string, string];
+};
+
+export type RightOperatorFocusData = {
+  type: "rightOperator.onFocus";
+  path: `${number}.condition.selected.value`;
+  index: number;
+};
+
+export type RightOperatorBlurData = {
+  type: "rightOperator.onBlur";
+  path: `${number}.condition.selected.value`;
+  index: number;
+};
+
+export type RightOperatorInputValueChangeData = {
+  type: "rightOperator.onInputValueChange";
+  path: `${number}.condition.selected.value`;
+  index: number;
+  value: string;
+};

--- a/src/components/ExperimentalFilters/useEvents.tsx
+++ b/src/components/ExperimentalFilters/useEvents.tsx
@@ -1,38 +1,7 @@
 import { useEffect } from "react";
 
-import {
-  ConditionBlurData,
-  ConditionChangeData,
-  ConditionFocusData,
-  FilterEventEmitter,
-  LeftOperatorBlurData,
-  LeftOperatorChangeData,
-  LeftOperatorFocusData,
-  LeftOperatorInputValueChangeData,
-  RightOperatorBlurData,
-  RightOperatorChangeData,
-  RightOperatorFocusData,
-  RightOperatorInputValueChangeData,
-  RowAddData,
-  RowRemoveData,
-} from "./EventEmitter";
-
-export interface FilterEvent extends Event {
-  detail?:
-    | RowAddData
-    | RowRemoveData
-    | LeftOperatorChangeData
-    | LeftOperatorFocusData
-    | LeftOperatorBlurData
-    | LeftOperatorInputValueChangeData
-    | ConditionChangeData
-    | ConditionFocusData
-    | ConditionBlurData
-    | RightOperatorChangeData
-    | RightOperatorFocusData
-    | RightOperatorBlurData
-    | RightOperatorInputValueChangeData;
-}
+import { FilterEvent } from "./types";
+import { FilterEventEmitter } from "./EventEmitter";
 
 type UseEventsProps = {
   onChange?: (event: FilterEvent["detail"]) => void;

--- a/src/components/ExperimentalFilters/utils.ts
+++ b/src/components/ExperimentalFilters/utils.ts
@@ -1,0 +1,40 @@
+import {
+  ComboboxOperator,
+  DateOperator,
+  DateTimeOperator,
+  InputOperator,
+  MultiselectOperator,
+  NumberRangeOperator,
+  SelectOperator,
+  SelectedOperator,
+} from "./types";
+
+export const isTextInput = (value: SelectedOperator): value is InputOperator =>
+  value.conditionValue?.type === "text";
+
+export const isNumberInput = (
+  value: SelectedOperator
+): value is InputOperator => value.conditionValue?.type === "number";
+
+export const isMultiselect = (
+  value: SelectedOperator
+): value is MultiselectOperator => value.conditionValue?.type === "multiselect";
+
+export const isCombobox = (
+  value: SelectedOperator
+): value is ComboboxOperator => value.conditionValue?.type === "combobox";
+
+export const isSelect = (value: SelectedOperator): value is SelectOperator =>
+  value.conditionValue?.type === "select";
+
+export const isNumberRange = (
+  value: SelectedOperator
+): value is NumberRangeOperator =>
+  value.conditionValue?.type === "number.range";
+
+export const isDate = (value: SelectedOperator): value is DateOperator =>
+  value.conditionValue?.type === "date";
+
+export const isDateTime = (
+  value: SelectedOperator
+): value is DateTimeOperator => value.conditionValue?.type === "datetime";


### PR DESCRIPTION
I want to merge this change because it adds error state and constrains to Experimental filters. I also did a bit of cleanup.

This PR closes #...

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->
<img width="692" alt="image" src="https://github.com/saleor/macaw-ui/assets/9116238/57d8e6b3-c7d1-48a8-87bc-e4cb7489f4d9">
<img width="688" alt="image" src="https://github.com/saleor/macaw-ui/assets/9116238/e9f6eedd-c13e-45ea-bd56-fe7060bdd4f3">


### Pull Request Checklist

- [ ] New components are exported from `./src/components/index.ts`.
- [ ] Storybook story is created and documentation properly generated.
