### PR TITLE
feat: add multiple errors support and date/datetime ranges to experimental filters

### DIFF
--- a/src/components/ExperimentalFilters/ExperimentalFilters.stories.tsx
+++ b/src/components/ExperimentalFilters/ExperimentalFilters.stories.tsx
@@ -300,11 +300,17 @@ export const Error = () => {
     <Template>
       <_ExperimentalFilters
         value={defaultValue}
-        error={{
-          row: 0,
-          rightText: "Some error here",
-          leftText: "Some error here",
-        }}
+        error={[
+          {
+            row: 0,
+            rightText: "Some error here",
+            leftText: "Some error here",
+          },
+          {
+            row: 2,
+            conditionText: "Some error here",
+          },
+        ]}
         leftOptions={[]}
       >
         <_ExperimentalFilters.Footer>

--- a/src/components/ExperimentalFilters/Filters.tsx
+++ b/src/components/ExperimentalFilters/Filters.tsx
@@ -3,6 +3,7 @@ import { Box, Text } from "..";
 import { RowComponent } from "./Row";
 import { FilterEventEmitter } from "./EventEmitter";
 
+import { createErrorLookup, getErrorByRowIndex } from "./errors";
 import { ExperimentalFiltersProps } from ".";
 
 type FiltersProps = Pick<
@@ -20,6 +21,8 @@ export const Filters = ({
   locale,
   error,
 }: FiltersProps) => {
+  const errorsByRowIndex = createErrorLookup(error);
+
   return (
     <Box
       display="grid"
@@ -42,7 +45,7 @@ export const Filters = ({
             key={`filterRow-${idx}`}
             leftOptions={leftOptions}
             emitter={emitter}
-            error={error?.row === idx ? error : undefined}
+            error={getErrorByRowIndex(errorsByRowIndex, idx)}
           />
         )
       )}

--- a/src/components/ExperimentalFilters/RightOperator.tsx
+++ b/src/components/ExperimentalFilters/RightOperator.tsx
@@ -17,7 +17,8 @@ type RightOperatorProps = {
   index: number;
   selected: SelectedOperator;
   emitter: FilterEventEmitter;
-  error?: string;
+  error: boolean;
+  helperText: string;
   disabled: boolean;
 };
 
@@ -27,6 +28,7 @@ export const RightOperator = ({
   emitter,
   error,
   disabled,
+  helperText,
 }: RightOperatorProps) => {
   if (isTextInput(selected)) {
     return (
@@ -41,8 +43,8 @@ export const RightOperator = ({
         onBlur={() => {
           emitter.blurRightOperator(index);
         }}
-        error={!!error}
-        helperText={error}
+        error={error}
+        helperText={helperText}
         disabled={disabled}
       />
     );
@@ -62,8 +64,8 @@ export const RightOperator = ({
         onBlur={() => {
           emitter.blurRightOperator(index);
         }}
-        error={!!error}
-        helperText={error}
+        error={error}
+        helperText={helperText}
         disabled={disabled}
       />
     );
@@ -85,8 +87,8 @@ export const RightOperator = ({
         onBlur={() => {
           emitter.blurRightOperator(index);
         }}
-        error={!!error}
-        helperText={error}
+        error={error}
+        helperText={helperText}
         disabled={disabled}
       />
     );
@@ -108,8 +110,8 @@ export const RightOperator = ({
         onBlur={() => {
           emitter.blurRightOperator(index);
         }}
-        error={!!error}
-        helperText={error}
+        error={error}
+        helperText={helperText}
         disabled={disabled}
       />
     );
@@ -127,8 +129,8 @@ export const RightOperator = ({
         onBlur={() => {
           emitter.blurRightOperator(index);
         }}
-        error={!!error}
-        helperText={error}
+        error={error}
+        helperText={helperText}
         disabled={disabled}
       />
     );
@@ -156,8 +158,8 @@ export const RightOperator = ({
           onChange={(e) => {
             emitter.changeRightOperator(index, [start, e.target.value]);
           }}
-          error={!!error}
-          helperText={error}
+          error={error}
+          helperText={helperText}
           disabled={disabled}
         />
       </Box>
@@ -172,8 +174,8 @@ export const RightOperator = ({
         onChange={(e) => {
           emitter.changeRightOperator(index, e.target.value);
         }}
-        error={!!error}
-        helperText={error}
+        error={error}
+        helperText={helperText}
         disabled={disabled}
       />
     );
@@ -187,8 +189,8 @@ export const RightOperator = ({
         onChange={(e) => {
           emitter.changeRightOperator(index, e.target.value);
         }}
-        error={!!error}
-        helperText={error}
+        error={error}
+        helperText={helperText}
         disabled={disabled}
       />
     );

--- a/src/components/ExperimentalFilters/Root.tsx
+++ b/src/components/ExperimentalFilters/Root.tsx
@@ -13,7 +13,7 @@ export type ExperimentalFiltersProps = {
   children?: ReactNode;
   onChange?: (event: FilterEvent["detail"]) => void;
   locale?: Record<string, string>;
-  error?: Error;
+  error?: Error[];
 };
 
 export const Root = ({

--- a/src/components/ExperimentalFilters/Row.tsx
+++ b/src/components/ExperimentalFilters/Row.tsx
@@ -5,13 +5,14 @@ import { ExperimentalFiltersProps } from "./Root";
 import { RightOperator } from "./RightOperator";
 import { getItemConstraint } from "./constrains";
 import { Row } from "./types";
+import { ErrorLookup } from "./errors";
 
 type RowProps = {
   item: Row;
   index: number;
   leftOptions: ExperimentalFiltersProps["leftOptions"];
   emitter: FilterEventEmitter;
-  error: ExperimentalFiltersProps["error"];
+  error: ErrorLookup[number];
 };
 
 export const RowComponent = ({
@@ -51,8 +52,8 @@ export const RowComponent = ({
         onBlur={() => {
           emitter.blurLeftOperator(index);
         }}
-        error={!!error?.leftText}
-        helperText={error?.leftText}
+        error={error.left.show}
+        helperText={error.left.text}
         disabled={constrain.disableLeftOperator}
       />
 
@@ -69,15 +70,16 @@ export const RowComponent = ({
         onBlur={() => {
           emitter.blurCondition(index);
         }}
-        error={!!error?.conditionText}
-        helperText={error?.conditionText}
+        error={error.condition.show}
+        helperText={error.condition.text}
       />
 
       <RightOperator
         selected={item.condition?.selected}
         index={index}
         emitter={emitter}
-        error={error?.rightText}
+        error={error.right.show}
+        helperText={error.right.text}
         disabled={constrain.disableRightOperator}
       />
 

--- a/src/components/ExperimentalFilters/errors.ts
+++ b/src/components/ExperimentalFilters/errors.ts
@@ -1,0 +1,64 @@
+import { Error } from "./types";
+
+export type ErrorLookup = {
+  [key: number]: {
+    left: {
+      text: string;
+      show: boolean;
+    };
+    right: {
+      text: string;
+      show: boolean;
+    };
+    condition: {
+      text: string;
+      show: boolean;
+    };
+  };
+};
+
+export const createErrorLookup = (errors: Error[] | undefined): ErrorLookup => {
+  const entries = errors?.map((error) => [
+    error.row,
+    {
+      left: {
+        text: error.leftText ?? "",
+        show: !!error.leftText,
+      },
+      right: {
+        text: error.rightText ?? "",
+        show: !!error.rightText,
+      },
+      condition: {
+        text: error.conditionText ?? "",
+        show: !!error.conditionText,
+      },
+    },
+  ]);
+
+  return entries ? Object.fromEntries(entries) : {};
+};
+
+export const getErrorByRowIndex = (
+  errorLookup: ErrorLookup,
+  rowIndex: number
+) => {
+  const possibleError = errorLookup[rowIndex];
+
+  return (
+    possibleError ?? {
+      left: {
+        text: "",
+        show: false,
+      },
+      right: {
+        text: "",
+        show: false,
+      },
+      condition: {
+        text: "",
+        show: false,
+      },
+    }
+  );
+};

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -111,7 +111,11 @@ const SelectInner = <T extends Option>(
         getToggleButtonProps={getToggleButtonProps}
       >
         <Box height={getBoxHeight(size)} {...props} ref={ref}>
-          <Text size={size} variant="body">
+          <Text
+            size={size}
+            variant="body"
+            color={error ? "textCriticalDefault" : "textNeutralDefault"}
+          >
             {selectedItem?.label}
           </Text>
         </Box>


### PR DESCRIPTION
I want to merge this change because it adds support for an array of errors inside Filters and ranges for date & datetime.

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->
<img width="713" alt="image" src="https://github.com/saleor/macaw-ui/assets/9116238/4c5aac59-794a-4677-9eb8-b18eeb9eeadc">
<img width="717" alt="image" src="https://github.com/saleor/macaw-ui/assets/9116238/6cf9b509-2539-410d-aea8-0cc2ef3688cd">


### Pull Request Checklist

- [ ] New components are exported from `./src/components/index.ts`.
- [ ] Storybook story is created and documentation properly generated.
