### PR TITLE
feat: add handler for interaction outside popover

### DIFF
--- a/src/components/Popover/Content.tsx
+++ b/src/components/Popover/Content.tsx
@@ -1,4 +1,5 @@
 import {
+  DismissableLayerProps,
   Content as RadixPopoverContent,
   Portal as RadixPopoverPortal,
 } from "@radix-ui/react-popover";
@@ -12,12 +13,14 @@ export interface PopoverContentProps {
   align?: "start" | "center" | "end";
   alignOffset?: number;
   avoidCollisions?: boolean;
+  onInteractOutside?: DismissableLayerProps["onInteractOutside"];
   children: React.ReactNode;
 }
 
 export const Content = ({
   children,
   className,
+  onInteractOutside,
   ...props
 }: PopoverContentProps) => {
   return (
@@ -26,6 +29,7 @@ export const Content = ({
         asChild
         className={classNames(popover, className)}
         data-macaw-ui-component="Popover.Content"
+        onInteractOutside={onInteractOutside}
         {...props}
       >
         {children}

--- a/src/components/Popover/Content.tsx
+++ b/src/components/Popover/Content.tsx
@@ -1,5 +1,4 @@
 import {
-  DismissableLayerProps,
   Content as RadixPopoverContent,
   Portal as RadixPopoverPortal,
 } from "@radix-ui/react-popover";
@@ -13,7 +12,7 @@ export interface PopoverContentProps {
   align?: "start" | "center" | "end";
   alignOffset?: number;
   avoidCollisions?: boolean;
-  onInteractOutside?: DismissableLayerProps["onInteractOutside"];
+  onInteractOutside?: () => void;
   children: React.ReactNode;
 }
 


### PR DESCRIPTION
I want to merge this change because it adds outside click/focus interaction to Popover.

It is based on Radix [`onInteractOutside`](https://www.radix-ui.com/docs/primitives/components/popover#content)

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

- [ ] New components are exported from `./src/components/index.ts`.
- [ ] Storybook story is created and documentation properly generated.
