### PR TITLE
fix: use sprinkles in popover arrow

### DIFF
--- a/src/components/Popover/Arrow.tsx
+++ b/src/components/Popover/Arrow.tsx
@@ -1,18 +1,18 @@
 import { Arrow as RadixPopoverArrow } from "@radix-ui/react-popover";
-import { vars } from "~/theme";
+import { Sprinkles, sprinkles } from "~/theme";
 import { classNames } from "~/utils";
 import { arrow } from "./Popover.css";
 
 export type PopoverArrowProps = {
-  backgroundColor?: string;
-  borderColor?: string;
+  fill?: Sprinkles["fill"];
+  stroke?: Sprinkles["stroke"];
   className?: string;
 };
 
 export const Arrow = ({
   className,
-  backgroundColor = vars.colors.background.subdued,
-  borderColor = vars.colors.border.neutralPlain,
+  fill = "subdued",
+  stroke = "neutralPlain",
 }: PopoverArrowProps) => {
   return (
     <RadixPopoverArrow className={classNames(arrow, className)} asChild>
@@ -27,8 +27,7 @@ export const Arrow = ({
         <path
           d="M8.08579 7.08579L0.5 -0.5H18.5L10.9142 7.08579C10.1332 7.86683 8.86684 7.86684 8.08579 7.08579Z"
           strokeLinejoin="round"
-          fill={backgroundColor}
-          stroke={borderColor}
+          className={sprinkles({ fill, stroke })}
         />
       </svg>
     </RadixPopoverArrow>

--- a/src/components/Popover/Popover.stories.tsx
+++ b/src/components/Popover/Popover.stories.tsx
@@ -24,7 +24,7 @@ export const Primary: Story = {
       // eslint-disable-next-line react/jsx-key
       <Popover.Content>
         <Box>
-          <Popover.Arrow />
+          <Popover.Arrow backgroundColor="surfaceNeutralPlain" />
           <Text>Popover content.</Text>
         </Box>
       </Popover.Content>,

--- a/src/components/Popover/Popover.stories.tsx
+++ b/src/components/Popover/Popover.stories.tsx
@@ -24,7 +24,7 @@ export const Primary: Story = {
       // eslint-disable-next-line react/jsx-key
       <Popover.Content>
         <Box>
-          <Popover.Arrow backgroundColor="surfaceNeutralPlain" />
+          <Popover.Arrow />
           <Text>Popover content.</Text>
         </Box>
       </Popover.Content>,

--- a/src/theme/sprinkles.css.ts
+++ b/src/theme/sprinkles.css.ts
@@ -229,6 +229,8 @@ const stateProperties = defineProperties({
     transition: { ease: "transform 0.3s", all: "all 0.3s ease-in-out" },
     textDecoration: ["none", "underline"],
     transform: [],
+    fill: { ...vars.colors.background, transparent: "transparent" },
+    stroke: { ...vars.colors.border, transparent: "transparent" },
   },
 });
 


### PR DESCRIPTION
I want to merge this change because it changes a bit API on `Popover.Arrow`:

| Before | After |
| ------- | ------- |
| `<Arrow backgroundColor={vars.colors.background.subdued} />` | `<Arrow fill="subdued" />` |
  

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

- [ ] New components are exported from `./src/components/index.ts`.
- [ ] Storybook story is created and documentation properly generated.
