### PR TITLE
fix: add missing types for `PageTab` and `UserChipMenuItem`

### DIFF
--- a/legacy/src/Alert/Alert.tsx
+++ b/legacy/src/Alert/Alert.tsx
@@ -8,9 +8,9 @@ import { CompleteIcon, InfoIcon, NotAllowedIcon, WarningIcon } from "../icons";
 import { AlertBase, AlertBaseProps, AlertVariant } from "./AlertBase";
 import useStyles from "./styles";
 
-export interface AlertProps extends AlertBaseProps {
+export interface AlertProps extends Omit<AlertBaseProps, "title"> {
   close?: boolean;
-  title?: string;
+  title?: string | React.ReactNode;
 }
 interface IconProps extends React.SVGProps<SVGSVGElement> {
   variant: AlertVariant;

--- a/legacy/src/PageTabs/PageTab.tsx
+++ b/legacy/src/PageTabs/PageTab.tsx
@@ -2,8 +2,18 @@ import Tab, { TabProps } from "@material-ui/core/Tab";
 import React from "react";
 
 import useStyles from "./styles";
+import { ButtonBaseProps } from "@material-ui/core";
 
-export const PageTab: React.FC<TabProps> = (props) => {
+type Props = ButtonBaseProps &
+  TabProps & {
+    component?: React.ElementType<any>;
+  };
+
+type PropsWithComponentProps<
+  C extends React.ElementType<any> | React.ElementType = "button"
+> = Props & React.ComponentProps<C>;
+
+export const PageTab: React.FC<PropsWithComponentProps> = (props) => {
   const classes = useStyles();
 
   return (

--- a/legacy/src/UserChipMenu/UserChipMenuItem.tsx
+++ b/legacy/src/UserChipMenu/UserChipMenuItem.tsx
@@ -4,7 +4,11 @@ import React from "react";
 import { useUserChipMenu } from "./context";
 
 export interface UserChipMenuItemProps extends Omit<MenuItemProps, "button"> {
+  component?: React.ElementType;
   leaveOpen?: boolean;
+  href?: string | any;
+  disableRipple?: boolean;
+  target?: string;
 }
 
 export const UserChipMenuItem: React.FC<UserChipMenuItemProps> = ({


### PR DESCRIPTION
I want to merge this change because it adds some missing types for `PageTab` and `UserChipMenuItem`.

This PR closes #...

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

- [ ] New components are exported from `./src/components/index.ts`.
- [ ] The storybook story is created and documentation is properly generated.
- [ ] New component is wrapped in `forwardRef`.
