### PR TITLE
feat: add instruction to install dependencies in legacy to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 <div align="center">
   <a href="https://macaw-ui-next.vercel.app/" rel="noopener" target="_blank"><img src="./legacy/stories/assets/macaw-ui-logo.svg" alt="Material-ui-pickers logo"></a></p>
-  
-  [![npm package](https://img.shields.io/npm/v/@saleor/macaw-ui.svg)](https://www.npmjs.com/package/@saleor/macaw-ui)
-  [![npm download](https://img.shields.io/npm/dm/@saleor/macaw-ui.svg)](https://www.npmjs.com/package/@saleor/macaw-ui)
-  [![Bundle Size](https://badgen.net/bundlephobia/minzip/@saleor/macaw-ui)](https://bundlephobia.com/package/@saleor/macaw-ui@latest)
+
+[![npm package](https://img.shields.io/npm/v/@saleor/macaw-ui.svg)](https://www.npmjs.com/package/@saleor/macaw-ui)
+[![npm download](https://img.shields.io/npm/dm/@saleor/macaw-ui.svg)](https://www.npmjs.com/package/@saleor/macaw-ui)
+[![Bundle Size](https://badgen.net/bundlephobia/minzip/@saleor/macaw-ui)](https://bundlephobia.com/package/@saleor/macaw-ui@latest)
+
 </div>
 
 # MacawUI
@@ -126,6 +127,7 @@ To begin, you need to install dependencies:
 
 ```sh
 pnpm install
+cd legacy && npm install
 ```
 
 Then, you can run the Storybook:


### PR DESCRIPTION
I want to merge this change because instruction to install dependencies in legacy for running push hook properly is missing.

This PR closes #...

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

- [ ] New components are exported from `./src/components/index.ts`.
- [ ] The storybook story is created and documentation is properly generated.
- [ ] New component is wrapped in `forwardRef`.
