### PR TITLE
fix: switch.item doesnt inherit box props

### DIFF
--- a/src/components/Switch/Item.tsx
+++ b/src/components/Switch/Item.tsx
@@ -22,6 +22,7 @@ export const SwitchItem = ({
 }: SwitchItemProps) => {
   return (
     <Switch.Item
+      asChild
       value={value}
       id={id}
       disabled={disabled}


### PR DESCRIPTION
I want to merge this change because it allows Switch.Item to use Box Props

This PR closes #511 

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

- [ ] New components are exported from `./src/components/index.ts`.
- [ ] The storybook story is created and documentation is properly generated.
- [ ] New component is wrapped in `forwardRef`.
