### PR TITLE
fix: dropdown block pointer events when used inside modal

### DIFF
--- a/src/hooks/useFloating.ts
+++ b/src/hooks/useFloating.ts
@@ -31,6 +31,7 @@ export const useFloating = (
     floatingStyles: {
       ...floatingStyles,
       zIndex: zIndexValue,
+      pointerEvents: "auto",
     },
   };
 };


### PR DESCRIPTION
I want to merge this change because it fixes an issue when we use Select, Combobox, Multiselect inside Modal components. The problem causes Modal through set pointer-event none to body element when open. The Portal used for dropdown doesn't have a set pointer event so it inherits it from body and that causes problem with select item in dropdown.

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

- [ ] New components are exported from `./src/components/index.ts`.
- [ ] The storybook story is created and documentation is properly generated.
- [ ] New component is wrapped in `forwardRef`.
