### PR TITLE
feat: add justify-self to sprinkles

### DIFF
--- a/src/theme/sprinkles.css.ts
+++ b/src/theme/sprinkles.css.ts
@@ -169,6 +169,7 @@ const responsiveProperties = defineProperties({
     opacity: ["0", "0.2", "0.4", "0.6", "0.8", "1"],
     fontWeight: vars.fontWeight,
     alignSelf: ["auto", "normal", "end", "center", "start"],
+    justifySelf: ["auto", "normal", "end", "center", "start"],
     visibility: ["visible", "hidden"],
   },
   shorthands: {


### PR DESCRIPTION
I want to merge this change because we need `justify-self` for various advanced grid-flexbox mixed layouts, right now specifically https://github.com/saleor/saleor-dashboard/issues/4219

This PR closes #...

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

- [ ] New components are exported from `./src/components/index.ts`.
- [ ] The storybook story is created and documentation is properly generated.
- [ ] New component is wrapped in `forwardRef`.
