### PR TITLE
fix: scroll inside modal content

### DIFF
--- a/src/components/Modal/Content.tsx
+++ b/src/components/Modal/Content.tsx
@@ -11,11 +11,12 @@ export const Content = ({ children }: ModalContentProps) => {
   return (
     <Dialog.Portal>
       <Dialog.Overlay asChild className={showContent}>
-        <Box backgroundColor="highlightDim" position="fixed" inset={0} />
+        <Box backgroundColor="highlightDim" position="fixed" inset={0}>
+          <Dialog.Content asChild className={showContent}>
+            {children}
+          </Dialog.Content>
+        </Box>
       </Dialog.Overlay>
-      <Dialog.Content asChild className={showContent}>
-        {children}
-      </Dialog.Content>
     </Dialog.Portal>
   );
 };

--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -1,7 +1,7 @@
 import { Meta, StoryObj } from "@storybook/react";
 
 import { useState } from "react";
-import { Box, Button, CloseIcon, Combobox, Text } from "..";
+import { Box, Button, CloseIcon, Text } from "..";
 
 import { Modal } from ".";
 
@@ -82,51 +82,4 @@ export const Controlled = () => {
       </Modal>
     </>
   );
-};
-
-export const WithComboboxInside: Story = {
-  args: {
-    children: [
-      // eslint-disable-next-line react/jsx-key
-      <Modal.Trigger>
-        <Button variant="tertiary">Show modal</Button>
-      </Modal.Trigger>,
-      // eslint-disable-next-line react/jsx-key
-      <Modal.Content>
-        <Box
-          backgroundColor="surfaceNeutralPlain"
-          boxShadow="modal"
-          __left="50%"
-          __top="50%"
-          position="fixed"
-          __maxWidth="400px"
-          __transform="translate(-50%, -50%)"
-        >
-          <Box
-            display="flex"
-            gap={3}
-            justifyContent="center"
-            alignItems="center"
-          >
-            <Combobox
-              label="Pick a color"
-              size="large"
-              value="color-black"
-              options={[
-                { value: "color-black", label: "Black" },
-                { value: "color-red", label: "Red" },
-                { value: "color-green", label: "Green" },
-                { value: "color-blue", label: "Blue" },
-                { value: "color-orange", label: "Orange" },
-                { value: "color-purple", label: "Purple" },
-              ]}
-            />
-            <Modal.Close>
-              <Button variant="tertiary" icon={<CloseIcon />} size="small" />
-            </Modal.Close>
-          </Box>
-        </Box>
-      </Modal.Content>,
-    ],
-  },
 };

--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -86,7 +86,6 @@ export const Controlled = () => {
 
 export const WithComboboxInside = () => {
   const [open, setOpen] = useState(false);
-  const [value, setValue] = useState<string | null>("color-black");
 
   return (
     <>
@@ -112,8 +111,7 @@ export const WithComboboxInside = () => {
               <Combobox
                 label="Pick a color"
                 size="large"
-                value={value}
-                onChange={(value) => setValue(value)}
+                value="color-black"
                 options={[
                   { value: "color-black", label: "Black" },
                   { value: "color-red", label: "Red" },

--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -84,50 +84,49 @@ export const Controlled = () => {
   );
 };
 
-export const WithComboboxInside = () => {
-  const [open, setOpen] = useState(false);
-
-  return (
-    <>
-      <Button onClick={() => setOpen(true)}>Show modal</Button>
-      <Modal open={open} onChange={setOpen}>
-        <Modal.Content>
+export const WithComboboxInside: Story = {
+  args: {
+    children: [
+      // eslint-disable-next-line react/jsx-key
+      <Modal.Trigger>
+        <Button variant="tertiary">Show modal</Button>
+      </Modal.Trigger>,
+      // eslint-disable-next-line react/jsx-key
+      <Modal.Content>
+        <Box
+          backgroundColor="surfaceNeutralPlain"
+          boxShadow="modal"
+          __left="50%"
+          __top="50%"
+          position="fixed"
+          __maxWidth="400px"
+          __transform="translate(-50%, -50%)"
+        >
           <Box
-            backgroundColor="surfaceNeutralPlain"
-            boxShadow="modal"
-            __left="50%"
-            __top="50%"
-            position="fixed"
-            __maxWidth="400px"
-            __transform="translate(-50%, -50%)"
+            display="flex"
+            gap={3}
+            justifyContent="center"
+            alignItems="center"
           >
-            <Box
-              display="flex"
-              gap={3}
-              padding={10}
-              justifyContent="center"
-              alignItems="center"
-            >
-              <Combobox
-                label="Pick a color"
-                size="large"
-                value="color-black"
-                options={[
-                  { value: "color-black", label: "Black" },
-                  { value: "color-red", label: "Red" },
-                  { value: "color-green", label: "Green" },
-                  { value: "color-blue", label: "Blue" },
-                  { value: "color-orange", label: "Orange" },
-                  { value: "color-purple", label: "Purple" },
-                ]}
-              />
-              <Modal.Close>
-                <Button variant="tertiary" icon={<CloseIcon />} size="small" />
-              </Modal.Close>
-            </Box>
+            <Combobox
+              label="Pick a color"
+              size="large"
+              value="color-black"
+              options={[
+                { value: "color-black", label: "Black" },
+                { value: "color-red", label: "Red" },
+                { value: "color-green", label: "Green" },
+                { value: "color-blue", label: "Blue" },
+                { value: "color-orange", label: "Orange" },
+                { value: "color-purple", label: "Purple" },
+              ]}
+            />
+            <Modal.Close>
+              <Button variant="tertiary" icon={<CloseIcon />} size="small" />
+            </Modal.Close>
           </Box>
-        </Modal.Content>
-      </Modal>
-    </>
-  );
+        </Box>
+      </Modal.Content>,
+    ],
+  },
 };

--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -1,7 +1,7 @@
 import { Meta, StoryObj } from "@storybook/react";
 
 import { useState } from "react";
-import { Box, Button, CloseIcon, Text } from "..";
+import { Box, Button, CloseIcon, Combobox, Text } from "..";
 
 import { Modal } from ".";
 
@@ -73,6 +73,56 @@ export const Controlled = () => {
               alignItems="center"
             >
               <Text>Modal content!</Text>
+              <Modal.Close>
+                <Button variant="tertiary" icon={<CloseIcon />} size="small" />
+              </Modal.Close>
+            </Box>
+          </Box>
+        </Modal.Content>
+      </Modal>
+    </>
+  );
+};
+
+export const WithComboboxInside = () => {
+  const [open, setOpen] = useState(false);
+  const [value, setValue] = useState<string | null>("color-black");
+
+  return (
+    <>
+      <Button onClick={() => setOpen(true)}>Show modal</Button>
+      <Modal open={open} onChange={setOpen}>
+        <Modal.Content>
+          <Box
+            backgroundColor="surfaceNeutralPlain"
+            boxShadow="modal"
+            __left="50%"
+            __top="50%"
+            position="fixed"
+            __maxWidth="400px"
+            __transform="translate(-50%, -50%)"
+          >
+            <Box
+              display="flex"
+              gap={3}
+              padding={10}
+              justifyContent="center"
+              alignItems="center"
+            >
+              <Combobox
+                label="Pick a color"
+                size="large"
+                value={value}
+                onChange={(value) => setValue(value)}
+                options={[
+                  { value: "color-black", label: "Black" },
+                  { value: "color-red", label: "Red" },
+                  { value: "color-green", label: "Green" },
+                  { value: "color-blue", label: "Blue" },
+                  { value: "color-orange", label: "Orange" },
+                  { value: "color-purple", label: "Purple" },
+                ]}
+              />
               <Modal.Close>
                 <Button variant="tertiary" icon={<CloseIcon />} size="small" />
               </Modal.Close>


### PR DESCRIPTION
I want to merge this change because it fix a problem that I can't scroll combobox dropdown inside modal.
According to Radix docs to be able to scroll we have to wrap Dialog.Content inside Dialog.Overlay
https://www.radix-ui.com/primitives/docs/components/dialog#scrollable-overlay


### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

- [ ] New components are exported from `./src/components/index.ts`.
- [ ] The storybook story is created and documentation is properly generated.
- [ ] New component is wrapped in `forwardRef`.
