### PR TITLE
Allow placeholder to be always visible

### DIFF
--- a/src/components/BaseInput/BaseInput.css.ts
+++ b/src/components/BaseInput/BaseInput.css.ts
@@ -255,6 +255,18 @@ export const inputRecipe = recipe({
         color: "textCriticalDefault",
       }),
     },
+    alwaysDisplayPlaceholder: {
+      true: {
+        selectors: {
+          "&::-webkit-input-placeholder": {
+            color: vars.colors.foreground.textNeutralSubdued,
+          },
+          "&::-moz-placeholder": {
+            color: vars.colors.foreground.textNeutralSubdued,
+          },
+        },
+      },
+    },
   },
   defaultVariants: {
     size: "medium",

--- a/src/components/Input/Input.stories.tsx
+++ b/src/components/Input/Input.stories.tsx
@@ -252,3 +252,27 @@ export const DateTime: Story = {
     },
   },
 };
+
+export const PlaceholderVisible: Story = {
+  args: {
+    alwaysDisplayPlaceholder: true,
+    placeholder: "Placeholder",
+    value: "",
+    label: null,
+  },
+  parameters: {
+    docs: {
+      source: {
+        code: `
+  const [value, setValue] = useState("");
+  
+  <Input
+    alwaysDisplayPlaceholder
+    placeholder="Placeholder"
+    value={value}
+    onChange={(e) => setValue(e.target.value)}
+  />`,
+      },
+    },
+  },
+};

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -26,6 +26,7 @@ export type InputProps = PropsWithBox<
       | "datetime-local";
     helperText?: ReactNode;
     endAdornment?: ReactNode;
+    alwaysDisplayPlaceholder?: boolean;
   }
 > &
   InputVariants;
@@ -51,6 +52,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
       flexShrink,
       width,
       endAdornment,
+      alwaysDisplayPlaceholder,
       ...props
     },
     ref
@@ -87,7 +89,9 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
             id={id}
             as="input"
             type={type}
-            className={classNames(inputRecipe({ size, error }))}
+            className={classNames(
+              inputRecipe({ size, error, alwaysDisplayPlaceholder })
+            )}
             disabled={disabled}
             value={inputValue}
             ref={ref}


### PR DESCRIPTION
I want to merge this change because it adds `alwaysDisplayPlaceholder` allowing for always visible placeholders in inputs. Currently they are only visible on focus, but there are some use cases (e.g. dynamic price value as placeholder)


### Screenshots
<img width="1097" alt="image" src="https://github.com/saleor/macaw-ui/assets/41952692/f2fec464-ed5b-4137-987c-ac7ee1cab90e">



### Pull Request Checklist

- [ ] New components are exported from `./src/components/index.ts`.
- [x] The storybook story is created and documentation is properly generated.
- [ ] New component is wrapped in `forwardRef`.
