### PR TITLE
feat: show empty text

### DIFF
--- a/src/components/BaseSelect/BaseSelect.css.ts
+++ b/src/components/BaseSelect/BaseSelect.css.ts
@@ -89,10 +89,3 @@ export const listItemStyle = style([
     borderRadius: listItemBorderRadius,
   },
 ]);
-
-export const noItemsStyle = style({
-  padding: vars.spacing[2],
-  borderRadius: listItemBorderRadius,
-  textAlign: "center",
-  fontStyle: "italic",
-});

--- a/src/components/BaseSelect/BaseSelect.css.ts
+++ b/src/components/BaseSelect/BaseSelect.css.ts
@@ -89,3 +89,10 @@ export const listItemStyle = style([
     borderRadius: listItemBorderRadius,
   },
 ]);
+
+export const noItemsStyle = style({
+  padding: vars.spacing[2],
+  borderRadius: listItemBorderRadius,
+  textAlign: "center",
+  fontStyle: "italic",
+});

--- a/src/components/BaseSelect/NoOptions.tsx
+++ b/src/components/BaseSelect/NoOptions.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from "react";
+import { Children, ReactNode, isValidElement } from "react";
 import { Text } from "~/components";
 
 interface NoOptionsProps {
@@ -11,4 +11,16 @@ export const NoOptions = ({ children }: NoOptionsProps) => {
       {children}
     </Text>
   );
+};
+
+export const hasNoOptions = (children: ReactNode): boolean => {
+  let hasNoOptions = false;
+
+  Children.forEach(children, (child) => {
+    if (isValidElement(child) && child.type === NoOptions) {
+      hasNoOptions = true;
+    }
+  });
+
+  return hasNoOptions;
 };

--- a/src/components/BaseSelect/NoOptions.tsx
+++ b/src/components/BaseSelect/NoOptions.tsx
@@ -1,0 +1,14 @@
+import { ReactNode } from "react";
+import { Text } from "~/components";
+
+interface NoOptionsProps {
+  children: ReactNode;
+}
+
+export const NoOptions = ({ children }: NoOptionsProps) => {
+  return (
+    <Text as="p" padding={2} textAlign="center" fontStyle="italic">
+      {children}
+    </Text>
+  );
+};

--- a/src/components/BaseSelect/helpers.ts
+++ b/src/components/BaseSelect/helpers.ts
@@ -1,13 +1,19 @@
 export const getListDisplayMode = ({
   isOpen,
   hasItemsToSelect,
+  showEmptyState,
   loading,
 }: {
   isOpen: boolean;
   hasItemsToSelect: boolean;
+  showEmptyState: boolean;
   loading?: boolean;
 }) => {
   if (isOpen && hasItemsToSelect) {
+    return "block";
+  }
+
+  if (isOpen && showEmptyState) {
     return "block";
   }
 

--- a/src/components/BaseSelect/index.ts
+++ b/src/components/BaseSelect/index.ts
@@ -2,3 +2,4 @@ export * from "./BaseSelect.css";
 export * from "./LoadingListItem";
 export * from "./types";
 export * from "./helpers";
+export * from "./NoOptions";

--- a/src/components/Combobox/Dynamic/DynamicCombobox.stories.tsx
+++ b/src/components/Combobox/Dynamic/DynamicCombobox.stories.tsx
@@ -163,3 +163,18 @@ export const Loading = () => {
     />
   );
 };
+
+export const NoOptions = () => {
+  return (
+    <DynamicCombobox
+      __width="200px"
+      value={null}
+      label="Pick star wars character"
+      onChange={() => undefined}
+      options={[]}
+      locale={{
+        noItems: "No items to select",
+      }}
+    />
+  );
+};

--- a/src/components/Combobox/Dynamic/DynamicCombobox.stories.tsx
+++ b/src/components/Combobox/Dynamic/DynamicCombobox.stories.tsx
@@ -172,11 +172,8 @@ export const NoOptions = () => {
       label="Pick star wars character"
       onChange={() => undefined}
       options={[]}
-      noOptionsComponent={
-        <DynamicCombobox.NoOptions>
-          No items to select
-        </DynamicCombobox.NoOptions>
-      }
-    />
+    >
+      <DynamicCombobox.NoOptions>No items to select</DynamicCombobox.NoOptions>
+    </DynamicCombobox>
   );
 };

--- a/src/components/Combobox/Dynamic/DynamicCombobox.stories.tsx
+++ b/src/components/Combobox/Dynamic/DynamicCombobox.stories.tsx
@@ -172,9 +172,11 @@ export const NoOptions = () => {
       label="Pick star wars character"
       onChange={() => undefined}
       options={[]}
-      locale={{
-        noItems: "No items to select",
-      }}
+      noOptionsComponent={
+        <DynamicCombobox.NoOptions>
+          No items to select
+        </DynamicCombobox.NoOptions>
+      }
     />
   );
 };

--- a/src/components/Combobox/Dynamic/DynamicCombobox.tsx
+++ b/src/components/Combobox/Dynamic/DynamicCombobox.tsx
@@ -19,7 +19,7 @@ import {
   listStyle,
   listWrapperRecipe,
   LoadingListItem,
-  noItemsStyle,
+  NoOptions,
   Option,
   SingleChangeHandler,
 } from "../../BaseSelect";
@@ -49,9 +49,9 @@ export type DynamicComboboxProps<T> = PropsWithBox<
     value: T | null;
     onInputValueChange?: (value: string) => void;
     loading?: boolean;
+    noOptionsComponent?: ReactNode;
     locale?: {
       loadingText?: string;
-      noItems?: string;
     };
     onScrollEnd?: () => void;
   }
@@ -75,6 +75,7 @@ const DynamicComboboxInner = <T extends Option>(
     onBlur,
     loading,
     locale,
+    noOptionsComponent,
     startAdornment,
     endAdornment,
     onScrollEnd,
@@ -148,7 +149,7 @@ const DynamicComboboxInner = <T extends Option>(
             isOpen,
             loading,
             hasItemsToSelect,
-            showEmptyState: !!locale?.noItems,
+            showEmptyState: !!noOptionsComponent,
           })}
           className={listWrapperRecipe({ size })}
         >
@@ -176,11 +177,7 @@ const DynamicComboboxInner = <T extends Option>(
                 </List.Item>
               ))}
 
-            {isOpen && !loading && !hasItemsToSelect && (
-              <Box className={noItemsStyle}>
-                <Text size="small">{locale?.noItems}</Text>
-              </Box>
-            )}
+            {isOpen && !loading && !hasItemsToSelect && noOptionsComponent}
 
             {loading && (
               <LoadingListItem size={size}>
@@ -205,10 +202,14 @@ const DynamicComboboxInner = <T extends Option>(
   );
 };
 
-export const DynamicCombobox = forwardRef(DynamicComboboxInner) as <
+const DynamicComboboxRoot = forwardRef(DynamicComboboxInner) as <
   T extends Option,
 >(
   props: DynamicComboboxProps<T> & {
     ref?: React.ForwardedRef<HTMLInputElement>;
   }
 ) => ReturnType<typeof DynamicComboboxInner>;
+
+export const DynamicCombobox = Object.assign(DynamicComboboxRoot, {
+  NoOptions,
+});

--- a/src/components/Combobox/Dynamic/DynamicCombobox.tsx
+++ b/src/components/Combobox/Dynamic/DynamicCombobox.tsx
@@ -19,6 +19,7 @@ import {
   listStyle,
   listWrapperRecipe,
   LoadingListItem,
+  noItemsStyle,
   Option,
   SingleChangeHandler,
 } from "../../BaseSelect";
@@ -50,6 +51,7 @@ export type DynamicComboboxProps<T> = PropsWithBox<
     loading?: boolean;
     locale?: {
       loadingText?: string;
+      noItems?: string;
     };
     onScrollEnd?: () => void;
   }
@@ -142,7 +144,12 @@ const DynamicComboboxInner = <T extends Option>(
       <Portal asChild ref={refs.setFloating} style={floatingStyles}>
         <Box
           position="relative"
-          display={getListDisplayMode({ isOpen, hasItemsToSelect, loading })}
+          display={getListDisplayMode({
+            isOpen,
+            loading,
+            hasItemsToSelect,
+            showEmptyState: !!locale?.noItems,
+          })}
           className={listWrapperRecipe({ size })}
         >
           <List
@@ -168,6 +175,13 @@ const DynamicComboboxInner = <T extends Option>(
                   {item?.endAdornment}
                 </List.Item>
               ))}
+
+            {isOpen && !loading && !hasItemsToSelect && (
+              <Box className={noItemsStyle}>
+                <Text size="small">{locale?.noItems}</Text>
+              </Box>
+            )}
+
             {loading && (
               <LoadingListItem size={size}>
                 {locale?.loadingText ?? "Loading"}

--- a/src/components/Combobox/Dynamic/DynamicCombobox.tsx
+++ b/src/components/Combobox/Dynamic/DynamicCombobox.tsx
@@ -15,6 +15,7 @@ import { HelperText, inputRecipe, InputVariants } from "../../BaseInput";
 import {
   getListDisplayMode,
   getListTextSize,
+  hasNoOptions,
   listItemStyle,
   listStyle,
   listWrapperRecipe,
@@ -49,7 +50,7 @@ export type DynamicComboboxProps<T> = PropsWithBox<
     value: T | null;
     onInputValueChange?: (value: string) => void;
     loading?: boolean;
-    noOptionsComponent?: ReactNode;
+    children?: ReactNode;
     locale?: {
       loadingText?: string;
     };
@@ -75,7 +76,7 @@ const DynamicComboboxInner = <T extends Option>(
     onBlur,
     loading,
     locale,
-    noOptionsComponent,
+    children,
     startAdornment,
     endAdornment,
     onScrollEnd,
@@ -149,7 +150,7 @@ const DynamicComboboxInner = <T extends Option>(
             isOpen,
             loading,
             hasItemsToSelect,
-            showEmptyState: !!noOptionsComponent,
+            showEmptyState: hasNoOptions(children),
           })}
           className={listWrapperRecipe({ size })}
         >
@@ -177,7 +178,7 @@ const DynamicComboboxInner = <T extends Option>(
                 </List.Item>
               ))}
 
-            {isOpen && !loading && !hasItemsToSelect && noOptionsComponent}
+            {isOpen && !loading && !hasItemsToSelect && children}
 
             {loading && (
               <LoadingListItem size={size}>

--- a/src/components/Combobox/Static/Combobox.tsx
+++ b/src/components/Combobox/Static/Combobox.tsx
@@ -14,6 +14,7 @@ import {
   SingleChangeHandler,
   getListDisplayMode,
   getListTextSize,
+  hasNoOptions,
   listItemStyle,
   listStyle,
   listWrapperRecipe,
@@ -42,7 +43,7 @@ export type ComboboxProps<T, V> = PropsWithBox<
     startAdornment?: (inputValue: V | null) => ReactNode;
     endAdornment?: (inputValue: V | null) => ReactNode;
     helperText?: ReactNode;
-    noOptionsComponent?: ReactNode;
+    children?: ReactNode;
     options: T[];
     onChange?: SingleChangeHandler<V | null>;
     value: V | null;
@@ -66,7 +67,7 @@ const ComboboxInner = <T extends Option, V extends Option | string>(
     onBlur,
     startAdornment,
     endAdornment,
-    noOptionsComponent,
+    children,
     ...props
   }: ComboboxProps<T, V>,
   ref: ForwardedRef<HTMLInputElement>
@@ -139,7 +140,7 @@ const ComboboxInner = <T extends Option, V extends Option | string>(
           display={getListDisplayMode({
             hasItemsToSelect,
             isOpen,
-            showEmptyState: !!noOptionsComponent,
+            showEmptyState: hasNoOptions(children),
           })}
           className={listWrapperRecipe({ size })}
         >
@@ -167,7 +168,7 @@ const ComboboxInner = <T extends Option, V extends Option | string>(
                 </List.Item>
               ))}
 
-            {isOpen && !hasItemsToSelect && noOptionsComponent}
+            {isOpen && !hasItemsToSelect && children}
           </List>
         </Box>
       </Portal>

--- a/src/components/Combobox/Static/Combobox.tsx
+++ b/src/components/Combobox/Static/Combobox.tsx
@@ -9,6 +9,7 @@ import {
 import { Box, List, PropsWithBox, Text } from "~/components";
 import { HelperText, InputVariants, inputRecipe } from "~/components/BaseInput";
 import {
+  NoOptions,
   Option,
   SingleChangeHandler,
   getListDisplayMode,
@@ -16,7 +17,6 @@ import {
   listItemStyle,
   listStyle,
   listWrapperRecipe,
-  noItemsStyle,
 } from "~/components/BaseSelect";
 import { classNames, isString } from "~/utils";
 
@@ -42,12 +42,10 @@ export type ComboboxProps<T, V> = PropsWithBox<
     startAdornment?: (inputValue: V | null) => ReactNode;
     endAdornment?: (inputValue: V | null) => ReactNode;
     helperText?: ReactNode;
+    noOptionsComponent?: ReactNode;
     options: T[];
     onChange?: SingleChangeHandler<V | null>;
     value: V | null;
-    locale?: {
-      noItems?: string;
-    };
   }
 > &
   InputVariants;
@@ -68,7 +66,7 @@ const ComboboxInner = <T extends Option, V extends Option | string>(
     onBlur,
     startAdornment,
     endAdornment,
-    locale,
+    noOptionsComponent,
     ...props
   }: ComboboxProps<T, V>,
   ref: ForwardedRef<HTMLInputElement>
@@ -141,7 +139,7 @@ const ComboboxInner = <T extends Option, V extends Option | string>(
           display={getListDisplayMode({
             hasItemsToSelect,
             isOpen,
-            showEmptyState: !!locale?.noItems,
+            showEmptyState: !!noOptionsComponent,
           })}
           className={listWrapperRecipe({ size })}
         >
@@ -169,11 +167,7 @@ const ComboboxInner = <T extends Option, V extends Option | string>(
                 </List.Item>
               ))}
 
-            {isOpen && !hasItemsToSelect && (
-              <Box className={noItemsStyle}>
-                <Text size="small">{locale?.noItems}</Text>
-              </Box>
-            )}
+            {isOpen && !hasItemsToSelect && noOptionsComponent}
           </List>
         </Box>
       </Portal>
@@ -187,9 +181,13 @@ const ComboboxInner = <T extends Option, V extends Option | string>(
   );
 };
 
-export const Combobox = forwardRef(ComboboxInner) as <
+const ComboboxRoot = forwardRef(ComboboxInner) as <
   T extends Option,
   V extends Option | string,
 >(
   props: ComboboxProps<T, V> & { ref?: React.ForwardedRef<HTMLInputElement> }
 ) => ReturnType<typeof ComboboxInner>;
+
+export const Combobox = Object.assign(ComboboxRoot, {
+  NoOptions,
+});

--- a/src/components/Combobox/Static/Combobox.tsx
+++ b/src/components/Combobox/Static/Combobox.tsx
@@ -11,10 +11,12 @@ import { HelperText, InputVariants, inputRecipe } from "~/components/BaseInput";
 import {
   Option,
   SingleChangeHandler,
+  getListDisplayMode,
   getListTextSize,
   listItemStyle,
   listStyle,
   listWrapperRecipe,
+  noItemsStyle,
 } from "~/components/BaseSelect";
 import { classNames, isString } from "~/utils";
 
@@ -43,6 +45,9 @@ export type ComboboxProps<T, V> = PropsWithBox<
     options: T[];
     onChange?: SingleChangeHandler<V | null>;
     value: V | null;
+    locale?: {
+      noItems?: string;
+    };
   }
 > &
   InputVariants;
@@ -63,6 +68,7 @@ const ComboboxInner = <T extends Option, V extends Option | string>(
     onBlur,
     startAdornment,
     endAdornment,
+    locale,
     ...props
   }: ComboboxProps<T, V>,
   ref: ForwardedRef<HTMLInputElement>
@@ -132,7 +138,11 @@ const ComboboxInner = <T extends Option, V extends Option | string>(
       <Portal asChild ref={refs.setFloating} style={floatingStyles}>
         <Box
           position="relative"
-          display={isOpen && hasItemsToSelect ? "block" : "none"}
+          display={getListDisplayMode({
+            hasItemsToSelect,
+            isOpen,
+            showEmptyState: !!locale?.noItems,
+          })}
           className={listWrapperRecipe({ size })}
         >
           <List
@@ -158,6 +168,12 @@ const ComboboxInner = <T extends Option, V extends Option | string>(
                   {item?.endAdornment}
                 </List.Item>
               ))}
+
+            {isOpen && !hasItemsToSelect && (
+              <Box className={noItemsStyle}>
+                <Text size="small">{locale?.noItems}</Text>
+              </Box>
+            )}
           </List>
         </Box>
       </Portal>

--- a/src/components/Combobox/Static/StaticCombobox.stories.tsx
+++ b/src/components/Combobox/Static/StaticCombobox.stories.tsx
@@ -242,10 +242,9 @@ export const NoOptions = () => {
         size="large"
         label="Label"
         onChange={() => undefined}
-        noOptionsComponent={
-          <Combobox.NoOptions>No items to select</Combobox.NoOptions>
-        }
-      />
+      >
+        <Combobox.NoOptions>No items to select</Combobox.NoOptions>
+      </Combobox>
     </Box>
   );
 };

--- a/src/components/Combobox/Static/StaticCombobox.stories.tsx
+++ b/src/components/Combobox/Static/StaticCombobox.stories.tsx
@@ -242,9 +242,9 @@ export const NoOptions = () => {
         size="large"
         label="Label"
         onChange={() => undefined}
-        locale={{
-          noItems: "No items to select",
-        }}
+        noOptionsComponent={
+          <Combobox.NoOptions>No items to select</Combobox.NoOptions>
+        }
       />
     </Box>
   );

--- a/src/components/Combobox/Static/StaticCombobox.stories.tsx
+++ b/src/components/Combobox/Static/StaticCombobox.stories.tsx
@@ -232,3 +232,20 @@ export const WithEllipsis = () => {
     </Box>
   );
 };
+
+export const NoOptions = () => {
+  return (
+    <Box __width="200px">
+      <Combobox
+        options={[]}
+        value={null}
+        size="large"
+        label="Label"
+        onChange={() => undefined}
+        locale={{
+          noItems: "No items to select",
+        }}
+      />
+    </Box>
+  );
+};

--- a/src/components/Multiselect/Common/useMultiselect.tsx
+++ b/src/components/Multiselect/Common/useMultiselect.tsx
@@ -32,6 +32,7 @@ const getItemsFilter = <T extends Option>(
 
 export const useMultiselect = <T extends Option, V extends Option | string>({
   selectedValues,
+  showEmptyState = false,
   options,
   onChange,
   onInputValueChange,
@@ -39,6 +40,7 @@ export const useMultiselect = <T extends Option, V extends Option | string>({
   onBlur,
 }: {
   selectedValues: V[];
+  showEmptyState?: boolean;
   options: T[];
   onChange?: MultiChangeHandler<V>;
   onInputValueChange?: (value: string) => void;
@@ -59,9 +61,10 @@ export const useMultiselect = <T extends Option, V extends Option | string>({
 
   const itemsToSelect = getItemsFilter<T>(selectedItems, inputValue, options);
 
-  const showInput = onInputValueChange
-    ? true
-    : selectedItems.length !== options.length;
+  const showInput =
+    onInputValueChange || showEmptyState
+      ? true
+      : selectedItems.length !== options.length;
 
   const typed = Boolean(selectedItems.length || active);
 

--- a/src/components/Multiselect/Dynamic/DynamicMultiselect.stories.tsx
+++ b/src/components/Multiselect/Dynamic/DynamicMultiselect.stories.tsx
@@ -99,15 +99,14 @@ export const NoOptions = () => {
         label="Pick a star wars characters"
         onChange={() => undefined}
         options={[]}
-        noOptionsComponent={
-          <DynamicMultiselect.NoOptions>
-            No items to select
-          </DynamicMultiselect.NoOptions>
-        }
         locale={{
           placeholderText: "Add character",
         }}
-      />
+      >
+        <DynamicMultiselect.NoOptions>
+          No items to select
+        </DynamicMultiselect.NoOptions>
+      </DynamicMultiselect>
     </Box>
   );
 };

--- a/src/components/Multiselect/Dynamic/DynamicMultiselect.stories.tsx
+++ b/src/components/Multiselect/Dynamic/DynamicMultiselect.stories.tsx
@@ -90,3 +90,20 @@ export const Default = () => {
     </Box>
   );
 };
+
+export const NoOptions = () => {
+  return (
+    <Box __width={300}>
+      <DynamicMultiselect
+        value={[]}
+        label="Pick a star wars characters"
+        onChange={() => undefined}
+        options={[]}
+        locale={{
+          placeholderText: "Add character",
+          noItems: "No items to select",
+        }}
+      />
+    </Box>
+  );
+};

--- a/src/components/Multiselect/Dynamic/DynamicMultiselect.stories.tsx
+++ b/src/components/Multiselect/Dynamic/DynamicMultiselect.stories.tsx
@@ -99,9 +99,13 @@ export const NoOptions = () => {
         label="Pick a star wars characters"
         onChange={() => undefined}
         options={[]}
+        noOptionsComponent={
+          <DynamicMultiselect.NoOptions>
+            No items to select
+          </DynamicMultiselect.NoOptions>
+        }
         locale={{
           placeholderText: "Add character",
-          noItems: "No items to select",
         }}
       />
     </Box>

--- a/src/components/Multiselect/Dynamic/DynamicMultiselect.tsx
+++ b/src/components/Multiselect/Dynamic/DynamicMultiselect.tsx
@@ -11,6 +11,7 @@ import { HelperText, InputVariants } from "~/components/BaseInput";
 import {
   getListDisplayMode,
   getListTextSize,
+  hasNoOptions,
   listItemStyle,
   listStyle,
   listWrapperRecipe,
@@ -51,7 +52,7 @@ export type DynamicMultiselectProps<T> = PropsWithBox<
     renderEndAdornment?: RenderEndAdornmentType;
     onInputValueChange?: (value: string) => void;
     loading?: boolean;
-    noOptionsComponent?: ReactNode;
+    children?: ReactNode;
     locale?: {
       loadingText?: string;
       placeholderText?: string;
@@ -79,7 +80,7 @@ const DynamicMultiselectInner = <T extends Option>(
     onFocus,
     onBlur,
     locale,
-    noOptionsComponent,
+    children,
     onScrollEnd,
     ...props
   }: DynamicMultiselectProps<T>,
@@ -104,7 +105,7 @@ const DynamicMultiselectInner = <T extends Option>(
     showInput,
   } = useMultiselect<T, T>({
     selectedValues: value,
-    showEmptyState: !!noOptionsComponent,
+    showEmptyState: hasNoOptions(children),
     onInputValueChange,
     options,
     onChange,
@@ -198,7 +199,7 @@ const DynamicMultiselectInner = <T extends Option>(
             isOpen,
             loading,
             hasItemsToSelect,
-            showEmptyState: !!noOptionsComponent,
+            showEmptyState: hasNoOptions(children),
           })}
           className={listWrapperRecipe({ size })}
         >
@@ -224,7 +225,7 @@ const DynamicMultiselectInner = <T extends Option>(
                 </List.Item>
               ))}
 
-            {isOpen && !loading && !hasItemsToSelect && noOptionsComponent}
+            {isOpen && !loading && !hasItemsToSelect && children}
 
             {loading && (
               <LoadingListItem size={size}>

--- a/src/components/Multiselect/Dynamic/DynamicMultiselect.tsx
+++ b/src/components/Multiselect/Dynamic/DynamicMultiselect.tsx
@@ -16,6 +16,7 @@ import {
   listWrapperRecipe,
   LoadingListItem,
   MultiChangeHandler,
+  noItemsStyle,
   Option,
 } from "~/components/BaseSelect";
 
@@ -53,6 +54,7 @@ export type DynamicMultiselectProps<T> = PropsWithBox<
     locale?: {
       loadingText?: string;
       placeholderText?: string;
+      noItems?: string;
     };
     onScrollEnd?: () => void;
   }
@@ -101,6 +103,7 @@ const DynamicMultiselectInner = <T extends Option>(
     showInput,
   } = useMultiselect<T, T>({
     selectedValues: value,
+    showEmptyState: !!locale?.noItems,
     onInputValueChange,
     options,
     onChange,
@@ -194,7 +197,12 @@ const DynamicMultiselectInner = <T extends Option>(
       <Portal asChild ref={refs.setFloating} style={floatingStyles}>
         <Box
           position="relative"
-          display={getListDisplayMode({ isOpen, hasItemsToSelect, loading })}
+          display={getListDisplayMode({
+            isOpen,
+            loading,
+            hasItemsToSelect,
+            showEmptyState: !!locale?.noItems,
+          })}
           className={listWrapperRecipe({ size })}
         >
           <List
@@ -218,6 +226,13 @@ const DynamicMultiselectInner = <T extends Option>(
                   <Text size={getListTextSize(size)}>{item.label}</Text>
                 </List.Item>
               ))}
+
+            {isOpen && !loading && !hasItemsToSelect && (
+              <Box className={noItemsStyle}>
+                <Text size="small">{locale?.noItems}</Text>
+              </Box>
+            )}
+
             {loading && (
               <LoadingListItem size={size}>
                 {locale?.loadingText || "Loading"}

--- a/src/components/Multiselect/Dynamic/DynamicMultiselect.tsx
+++ b/src/components/Multiselect/Dynamic/DynamicMultiselect.tsx
@@ -16,7 +16,7 @@ import {
   listWrapperRecipe,
   LoadingListItem,
   MultiChangeHandler,
-  noItemsStyle,
+  NoOptions,
   Option,
 } from "~/components/BaseSelect";
 
@@ -51,10 +51,10 @@ export type DynamicMultiselectProps<T> = PropsWithBox<
     renderEndAdornment?: RenderEndAdornmentType;
     onInputValueChange?: (value: string) => void;
     loading?: boolean;
+    noOptionsComponent?: ReactNode;
     locale?: {
       loadingText?: string;
       placeholderText?: string;
-      noItems?: string;
     };
     onScrollEnd?: () => void;
   }
@@ -79,6 +79,7 @@ const DynamicMultiselectInner = <T extends Option>(
     onFocus,
     onBlur,
     locale,
+    noOptionsComponent,
     onScrollEnd,
     ...props
   }: DynamicMultiselectProps<T>,
@@ -103,7 +104,7 @@ const DynamicMultiselectInner = <T extends Option>(
     showInput,
   } = useMultiselect<T, T>({
     selectedValues: value,
-    showEmptyState: !!locale?.noItems,
+    showEmptyState: !!noOptionsComponent,
     onInputValueChange,
     options,
     onChange,
@@ -197,7 +198,7 @@ const DynamicMultiselectInner = <T extends Option>(
             isOpen,
             loading,
             hasItemsToSelect,
-            showEmptyState: !!locale?.noItems,
+            showEmptyState: !!noOptionsComponent,
           })}
           className={listWrapperRecipe({ size })}
         >
@@ -223,11 +224,7 @@ const DynamicMultiselectInner = <T extends Option>(
                 </List.Item>
               ))}
 
-            {isOpen && !loading && !hasItemsToSelect && (
-              <Box className={noItemsStyle}>
-                <Text size="small">{locale?.noItems}</Text>
-              </Box>
-            )}
+            {isOpen && !loading && !hasItemsToSelect && noOptionsComponent}
 
             {loading && (
               <LoadingListItem size={size}>
@@ -252,10 +249,14 @@ const DynamicMultiselectInner = <T extends Option>(
   );
 };
 
-export const DynamicMultiselect = forwardRef(DynamicMultiselectInner) as <
+const DynamicMultiselectRoot = forwardRef(DynamicMultiselectInner) as <
   T extends Option,
 >(
   props: DynamicMultiselectProps<T> & {
     ref?: React.ForwardedRef<HTMLInputElement>;
   }
 ) => ReturnType<typeof DynamicMultiselectInner>;
+
+export const DynamicMultiselect = Object.assign(DynamicMultiselectRoot, {
+  NoOptions,
+});

--- a/src/components/Multiselect/Static/Multiselect.stories.tsx
+++ b/src/components/Multiselect/Static/Multiselect.stories.tsx
@@ -210,10 +210,9 @@ export const NoOptions = () => {
         value={[]}
         onChange={() => undefined}
         options={[]}
-        noOptionsComponent={
-          <Multiselect.NoOptions>No items to select</Multiselect.NoOptions>
-        }
-      />
+      >
+        <Multiselect.NoOptions>No items to select</Multiselect.NoOptions>
+      </Multiselect>
     </Box>
   );
 };

--- a/src/components/Multiselect/Static/Multiselect.stories.tsx
+++ b/src/components/Multiselect/Static/Multiselect.stories.tsx
@@ -196,3 +196,20 @@ export const WithStringAsValues = () => {
     </Box>
   );
 };
+
+export const NoOptions = () => {
+  return (
+    <Box __width={300}>
+      <Multiselect
+        label="Pick colors"
+        size="large"
+        value={[]}
+        onChange={() => undefined}
+        options={[]}
+        locale={{
+          noItems: "No items to select",
+        }}
+      />
+    </Box>
+  );
+};

--- a/src/components/Multiselect/Static/Multiselect.stories.tsx
+++ b/src/components/Multiselect/Static/Multiselect.stories.tsx
@@ -210,9 +210,9 @@ export const NoOptions = () => {
         value={[]}
         onChange={() => undefined}
         options={[]}
-        locale={{
-          noItems: "No items to select",
-        }}
+        noOptionsComponent={
+          <Multiselect.NoOptions>No items to select</Multiselect.NoOptions>
+        }
       />
     </Box>
   );

--- a/src/components/Multiselect/Static/Multiselect.tsx
+++ b/src/components/Multiselect/Static/Multiselect.tsx
@@ -14,6 +14,7 @@ import {
   listStyle,
   listWrapperRecipe,
   MultiChangeHandler,
+  noItemsStyle,
   Option,
 } from "~/components/BaseSelect";
 
@@ -47,6 +48,7 @@ export type MultiselectProps<T, V> = PropsWithBox<
     renderEndAdornment?: RenderEndAdornmentType;
     locale?: {
       inputText?: string;
+      noItems?: string;
     };
   }
 > &
@@ -93,6 +95,7 @@ const MultiselectInner = <T extends Option, V extends Option | string>(
     showInput,
   } = useMultiselect({
     selectedValues: value,
+    showEmptyState: !!locale.noItems,
     options,
     onChange,
     onFocus,
@@ -183,7 +186,7 @@ const MultiselectInner = <T extends Option, V extends Option | string>(
       <Portal asChild ref={refs.setFloating} style={floatingStyles}>
         <Box
           position="relative"
-          display={isOpen && hasItemsToSelect ? "block" : "none"}
+          display={isOpen ? "block" : "none"}
           className={listWrapperRecipe({ size })}
         >
           <List
@@ -207,6 +210,12 @@ const MultiselectInner = <T extends Option, V extends Option | string>(
                   <Text size={getListTextSize(size)}>{item.label}</Text>
                 </List.Item>
               ))}
+
+            {isOpen && !hasItemsToSelect && (
+              <Box className={noItemsStyle}>
+                <Text size="small">{locale.noItems}</Text>
+              </Box>
+            )}
           </List>
         </Box>
       </Portal>

--- a/src/components/Multiselect/Static/Multiselect.tsx
+++ b/src/components/Multiselect/Static/Multiselect.tsx
@@ -14,7 +14,7 @@ import {
   listStyle,
   listWrapperRecipe,
   MultiChangeHandler,
-  noItemsStyle,
+  NoOptions,
   Option,
 } from "~/components/BaseSelect";
 
@@ -46,9 +46,9 @@ export type MultiselectProps<T, V> = PropsWithBox<
     onChange?: MultiChangeHandler<V>;
     value: V[];
     renderEndAdornment?: RenderEndAdornmentType;
+    noOptionsComponent?: ReactNode;
     locale?: {
       inputText?: string;
-      noItems?: string;
     };
   }
 > &
@@ -69,6 +69,7 @@ const MultiselectInner = <T extends Option, V extends Option | string>(
     value = [],
     onFocus,
     onBlur,
+    noOptionsComponent,
     locale = {
       inputText: "Add item",
     },
@@ -95,7 +96,7 @@ const MultiselectInner = <T extends Option, V extends Option | string>(
     showInput,
   } = useMultiselect({
     selectedValues: value,
-    showEmptyState: !!locale.noItems,
+    showEmptyState: !!noOptionsComponent,
     options,
     onChange,
     onFocus,
@@ -207,11 +208,7 @@ const MultiselectInner = <T extends Option, V extends Option | string>(
                 </List.Item>
               ))}
 
-            {isOpen && !hasItemsToSelect && (
-              <Box className={noItemsStyle}>
-                <Text size="small">{locale.noItems}</Text>
-              </Box>
-            )}
+            {isOpen && !hasItemsToSelect && noOptionsComponent}
           </List>
         </Box>
       </Portal>
@@ -225,9 +222,13 @@ const MultiselectInner = <T extends Option, V extends Option | string>(
   );
 };
 
-export const Multiselect = forwardRef(MultiselectInner) as <
+export const MultiselectRoot = forwardRef(MultiselectInner) as <
   T extends Option,
   V extends Option | string,
 >(
   props: MultiselectProps<T, V> & { ref?: React.ForwardedRef<HTMLInputElement> }
 ) => ReturnType<typeof MultiselectInner>;
+
+export const Multiselect = Object.assign(MultiselectRoot, {
+  NoOptions,
+});

--- a/src/components/Multiselect/Static/Multiselect.tsx
+++ b/src/components/Multiselect/Static/Multiselect.tsx
@@ -10,6 +10,7 @@ import { Box, List, PropsWithBox, Text } from "~/components";
 import { HelperText, InputVariants } from "~/components/BaseInput";
 import {
   getListTextSize,
+  hasNoOptions,
   listItemStyle,
   listStyle,
   listWrapperRecipe,
@@ -46,7 +47,7 @@ export type MultiselectProps<T, V> = PropsWithBox<
     onChange?: MultiChangeHandler<V>;
     value: V[];
     renderEndAdornment?: RenderEndAdornmentType;
-    noOptionsComponent?: ReactNode;
+    children?: ReactNode;
     locale?: {
       inputText?: string;
     };
@@ -69,7 +70,7 @@ const MultiselectInner = <T extends Option, V extends Option | string>(
     value = [],
     onFocus,
     onBlur,
-    noOptionsComponent,
+    children,
     locale = {
       inputText: "Add item",
     },
@@ -96,7 +97,7 @@ const MultiselectInner = <T extends Option, V extends Option | string>(
     showInput,
   } = useMultiselect({
     selectedValues: value,
-    showEmptyState: !!noOptionsComponent,
+    showEmptyState: hasNoOptions(children),
     options,
     onChange,
     onFocus,
@@ -208,7 +209,7 @@ const MultiselectInner = <T extends Option, V extends Option | string>(
                 </List.Item>
               ))}
 
-            {isOpen && !hasItemsToSelect && noOptionsComponent}
+            {isOpen && !hasItemsToSelect && children}
           </List>
         </Box>
       </Portal>

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -177,3 +177,20 @@ export const WithEllipsis = () => {
     </Box>
   );
 };
+
+export const NoOptions = () => {
+  return (
+    <Box __width="200px">
+      <Select
+        options={[]}
+        value={null}
+        size="large"
+        label="Label"
+        onChange={() => undefined}
+        locale={{
+          noItems: "No items to select",
+        }}
+      />
+    </Box>
+  );
+};

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -191,10 +191,9 @@ export const NoOptions = () => {
         size="large"
         label="Label"
         onChange={() => undefined}
-        noOptionsComponent={
-          <Select.NoOptions>No items to select</Select.NoOptions>
-        }
-      />
+      >
+        <Select.NoOptions>No items to select</Select.NoOptions>
+      </Select>
     </Box>
   );
 };

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -191,9 +191,9 @@ export const NoOptions = () => {
         size="large"
         label="Label"
         onChange={() => undefined}
-        locale={{
-          noItems: "No items to select",
-        }}
+        noOptionsComponent={
+          <Select.NoOptions>No items to select</Select.NoOptions>
+        }
       />
     </Box>
   );

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -17,7 +17,9 @@ import {
   listItemStyle,
   listStyle,
   listWrapperRecipe,
+  noItemsStyle,
 } from "../BaseSelect";
+import { getListDisplayMode } from "../BaseSelect/helpers";
 
 import { SelectWrapper } from "./SelectWrapper";
 import { useSelect } from "./useSelect";
@@ -41,6 +43,9 @@ export type SelectProps<T, V> = PropsWithBox<
     options: T[];
     onChange?: SingleChangeHandler<V>;
     value: V | null;
+    locale?: {
+      noItems?: string;
+    };
   }
 > &
   InputVariants;
@@ -70,6 +75,7 @@ const SelectInner = <T extends Option, V extends Option | string>(
     onChange,
     onFocus,
     onBlur,
+    locale,
     ...props
   }: SelectProps<T, V>,
   ref: ForwardedRef<HTMLElement>
@@ -133,7 +139,11 @@ const SelectInner = <T extends Option, V extends Option | string>(
       <Portal asChild ref={refs.setFloating} style={floatingStyles}>
         <Box
           position="relative"
-          display={isOpen && hasItemsToSelect ? "block" : "none"}
+          display={getListDisplayMode({
+            isOpen,
+            hasItemsToSelect,
+            showEmptyState: !!locale?.noItems,
+          })}
           className={listWrapperRecipe({ size })}
         >
           <List
@@ -157,6 +167,12 @@ const SelectInner = <T extends Option, V extends Option | string>(
                   <Text size={getListTextSize(size)}>{item.label}</Text>
                 </List.Item>
               ))}
+
+            {isOpen && !hasItemsToSelect && (
+              <Box className={noItemsStyle}>
+                <Text size="small">{locale?.noItems}</Text>
+              </Box>
+            )}
           </List>
         </Box>
       </Portal>

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -15,6 +15,7 @@ import {
   Option,
   SingleChangeHandler,
   getListTextSize,
+  hasNoOptions,
   listItemStyle,
   listStyle,
   listWrapperRecipe,
@@ -43,7 +44,7 @@ export type SelectProps<T, V> = PropsWithBox<
     options: T[];
     onChange?: SingleChangeHandler<V>;
     value: V | null;
-    noOptionsComponent?: ReactNode;
+    children?: ReactNode;
   }
 > &
   InputVariants;
@@ -73,7 +74,7 @@ const SelectInner = <T extends Option, V extends Option | string>(
     onChange,
     onFocus,
     onBlur,
-    noOptionsComponent,
+    children,
     ...props
   }: SelectProps<T, V>,
   ref: ForwardedRef<HTMLElement>
@@ -140,7 +141,7 @@ const SelectInner = <T extends Option, V extends Option | string>(
           display={getListDisplayMode({
             isOpen,
             hasItemsToSelect,
-            showEmptyState: !!noOptionsComponent,
+            showEmptyState: hasNoOptions(children),
           })}
           className={listWrapperRecipe({ size })}
         >
@@ -166,7 +167,7 @@ const SelectInner = <T extends Option, V extends Option | string>(
                 </List.Item>
               ))}
 
-            {isOpen && !hasItemsToSelect && noOptionsComponent}
+            {isOpen && !hasItemsToSelect && children}
           </List>
         </Box>
       </Portal>

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -11,13 +11,13 @@ import { isString } from "~/utils";
 import { Box, List, PropsWithBox, Text } from "..";
 import { HelperText, InputVariants } from "../BaseInput";
 import {
+  NoOptions,
   Option,
   SingleChangeHandler,
   getListTextSize,
   listItemStyle,
   listStyle,
   listWrapperRecipe,
-  noItemsStyle,
 } from "../BaseSelect";
 import { getListDisplayMode } from "../BaseSelect/helpers";
 
@@ -43,9 +43,7 @@ export type SelectProps<T, V> = PropsWithBox<
     options: T[];
     onChange?: SingleChangeHandler<V>;
     value: V | null;
-    locale?: {
-      noItems?: string;
-    };
+    noOptionsComponent?: ReactNode;
   }
 > &
   InputVariants;
@@ -75,7 +73,7 @@ const SelectInner = <T extends Option, V extends Option | string>(
     onChange,
     onFocus,
     onBlur,
-    locale,
+    noOptionsComponent,
     ...props
   }: SelectProps<T, V>,
   ref: ForwardedRef<HTMLElement>
@@ -142,7 +140,7 @@ const SelectInner = <T extends Option, V extends Option | string>(
           display={getListDisplayMode({
             isOpen,
             hasItemsToSelect,
-            showEmptyState: !!locale?.noItems,
+            showEmptyState: !!noOptionsComponent,
           })}
           className={listWrapperRecipe({ size })}
         >
@@ -168,11 +166,7 @@ const SelectInner = <T extends Option, V extends Option | string>(
                 </List.Item>
               ))}
 
-            {isOpen && !hasItemsToSelect && (
-              <Box className={noItemsStyle}>
-                <Text size="small">{locale?.noItems}</Text>
-              </Box>
-            )}
+            {isOpen && !hasItemsToSelect && noOptionsComponent}
           </List>
         </Box>
       </Portal>
@@ -186,9 +180,13 @@ const SelectInner = <T extends Option, V extends Option | string>(
   );
 };
 
-export const Select = forwardRef(SelectInner) as <
+const SelectRoot = forwardRef(SelectInner) as <
   T extends Option,
   V extends Option | string,
 >(
   props: SelectProps<T, V> & { ref?: React.ForwardedRef<HTMLElement> }
 ) => ReturnType<typeof SelectInner>;
+
+export const Select = Object.assign(SelectRoot, {
+  NoOptions,
+});

--- a/src/theme/sprinkles.css.ts
+++ b/src/theme/sprinkles.css.ts
@@ -141,6 +141,7 @@ const responsiveProperties = defineProperties({
       "100%": "100%",
     },
     fontSize: { ...vars.fontSize, inherit: "inherit" },
+    fontStyle: ["normal", "italic"],
     lineHeight: { ...vars.lineHeight, inherit: "inherit" },
     textAlign: ["center", "left", "right"],
     borderLeftWidth: vars.borderWidth,


### PR DESCRIPTION
I want to merge this change because it allows displaying text inside the dropdown when there are no options to show to give use clear feedback.
It applies to all selects, multiselects and comboboxes.

This PR closes #...

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

- [ ] New components are exported from `./src/components/index.ts`.
- [ ] The storybook story is created and documentation is properly generated.
- [ ] New component is wrapped in `forwardRef`.
