### PR TITLE
fix: pass string onChange when value is string for selects

### DIFF
--- a/src/components/Combobox/Common/useCombobox.tsx
+++ b/src/components/Combobox/Common/useCombobox.tsx
@@ -6,7 +6,6 @@ import {
 import { FocusEvent, useState } from "react";
 
 import { Option, SingleChangeHandler } from "~/components/BaseSelect";
-import { isString } from "~/utils";
 
 const getItemsFilter = <T extends Option>(
   inputValue: string | undefined,
@@ -26,6 +25,7 @@ const getItemsFilter = <T extends Option>(
 export const useCombobox = <T extends Option, V extends string | Option>({
   selectedItem,
   options,
+  isValuePassedAsString,
   onChange,
   onInputValueChange,
   onFocus,
@@ -33,6 +33,7 @@ export const useCombobox = <T extends Option, V extends string | Option>({
 }: {
   selectedItem: T | null | undefined;
   options: T[];
+  isValuePassedAsString: boolean;
   onChange?: SingleChangeHandler<V | null>;
   onInputValueChange?: (value: string) => void;
   onFocus?: (e: FocusEvent<HTMLInputElement, Element>) => void;
@@ -58,7 +59,7 @@ export const useCombobox = <T extends Option, V extends string | Option>({
     selectedItem,
     onSelectedItemChange: ({ selectedItem }) => {
       if (selectedItem) {
-        const selectedValue = isString(selectedItem)
+        const selectedValue = isValuePassedAsString
           ? selectedItem.value
           : selectedItem;
         onChange?.(selectedValue as V);

--- a/src/components/Combobox/Dynamic/DynamicCombobox.tsx
+++ b/src/components/Combobox/Dynamic/DynamicCombobox.tsx
@@ -99,6 +99,7 @@ const DynamicComboboxInner = <T extends Option>(
   } = useCombobox({
     selectedItem: value,
     options,
+    isValuePassedAsString: false,
     onChange,
     onInputValueChange,
     onFocus,

--- a/src/components/Combobox/Static/Combobox.tsx
+++ b/src/components/Combobox/Static/Combobox.tsx
@@ -72,6 +72,8 @@ const ComboboxInner = <T extends Option, V extends Option | string>(
   }: ComboboxProps<T, V>,
   ref: ForwardedRef<HTMLInputElement>
 ) => {
+  const isValuePassedAsString = isString(value);
+
   const {
     active,
     typed,
@@ -85,9 +87,10 @@ const ComboboxInner = <T extends Option, V extends Option | string>(
     itemsToSelect,
     hasItemsToSelect,
   } = useCombobox({
-    selectedItem: isString(value)
+    selectedItem: isValuePassedAsString
       ? options.find((option) => option.value === value)
       : value,
+    isValuePassedAsString,
     options,
     onChange,
     onFocus,

--- a/src/components/Multiselect/Common/useMultiselect.tsx
+++ b/src/components/Multiselect/Common/useMultiselect.tsx
@@ -79,7 +79,7 @@ export const useMultiselect = <T extends Option, V extends Option | string>({
           case useMultipleSelection.stateChangeTypes.DropdownKeyDownBackspace:
           case useMultipleSelection.stateChangeTypes
             .FunctionRemoveSelectedItem: {
-            const selected = isStringArray(selectedItems)
+            const selected = isStringArray(selectedValues)
               ? newSelectedItems?.map((item) => item.value)
               : newSelectedItems;
             onChange?.(selected as V[]);
@@ -130,7 +130,7 @@ export const useMultiselect = <T extends Option, V extends Option | string>({
         case useCombobox.stateChangeTypes.ItemClick:
         case useCombobox.stateChangeTypes.InputBlur:
           if (newSelectedItem) {
-            const selected = isStringArray(selectedItems)
+            const selected = isStringArray(selectedValues)
               ? [...selectedItems.map((i) => i.value), newSelectedItem.value]
               : [...selectedItems, newSelectedItem];
             onChange?.(selected as V[]);

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -79,6 +79,7 @@ const SelectInner = <T extends Option, V extends Option | string>(
   }: SelectProps<T, V>,
   ref: ForwardedRef<HTMLElement>
 ) => {
+  const isValuePassedAsString = isString(value);
   const {
     active,
     typed,
@@ -91,9 +92,10 @@ const SelectInner = <T extends Option, V extends Option | string>(
     highlightedIndex,
     hasItemsToSelect,
   } = useSelect({
-    value: isString(value)
+    value: isValuePassedAsString
       ? options.find((item) => item.value === value)
       : value,
+    isValuePassedAsString,
     options,
     onChange,
     onFocus,

--- a/src/components/Select/useSelect.tsx
+++ b/src/components/Select/useSelect.tsx
@@ -5,19 +5,19 @@ import {
 } from "downshift";
 import { FocusEvent, useState } from "react";
 
-import { isString } from "~/utils";
-
 import { Option } from "../BaseSelect";
 import { SelectProps } from "./Select";
 
 export const useSelect = <T extends Option, V extends string | Option>({
   value,
+  isValuePassedAsString,
   options,
   onChange,
   onFocus,
   onBlur,
 }: {
   value: T | null | undefined;
+  isValuePassedAsString: boolean;
   options: T[];
   onChange?: SelectProps<T, V>["onChange"];
   onFocus?: (e: FocusEvent<HTMLElement, Element>) => void;
@@ -40,7 +40,7 @@ export const useSelect = <T extends Option, V extends string | Option>({
     itemToString: (item) => item?.label ?? "",
     onSelectedItemChange: ({ selectedItem }) => {
       if (selectedItem) {
-        const selectedValue = isString(selectedItem)
+        const selectedValue = isValuePassedAsString
           ? selectedItem.value
           : selectedItem;
         onChange?.(selectedValue as V);


### PR DESCRIPTION
I want to merge this change because it fixes case when user passes `string` as value to `Select`, `Combobox` and `Multiselect` - now it should return `string` onChange.

This PR closes #...

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

- [ ] New components are exported from `./src/components/index.ts`.
- [ ] The storybook story is created and documentation is properly generated.
- [ ] New component is wrapped in `forwardRef`.
