### PR TITLE
fix: open select,combobox, multiselect when disabled

### DIFF
--- a/src/components/BaseSelect/helpers.ts
+++ b/src/components/BaseSelect/helpers.ts
@@ -1,14 +1,20 @@
 export const getListDisplayMode = ({
   isOpen,
+  disabled,
   hasItemsToSelect,
   showEmptyState,
   loading,
 }: {
   isOpen: boolean;
+  disabled: boolean;
   hasItemsToSelect: boolean;
   showEmptyState: boolean;
   loading?: boolean;
 }) => {
+  if (disabled) {
+    return "none";
+  }
+
   if (isOpen && hasItemsToSelect) {
     return "block";
   }

--- a/src/components/Combobox/Dynamic/DynamicCombobox.tsx
+++ b/src/components/Combobox/Dynamic/DynamicCombobox.tsx
@@ -148,6 +148,7 @@ const DynamicComboboxInner = <T extends Option>(
           position="relative"
           display={getListDisplayMode({
             isOpen,
+            disabled,
             loading,
             hasItemsToSelect,
             showEmptyState: hasNoOptions(children),

--- a/src/components/Combobox/Static/Combobox.tsx
+++ b/src/components/Combobox/Static/Combobox.tsx
@@ -138,6 +138,7 @@ const ComboboxInner = <T extends Option, V extends Option | string>(
         <Box
           position="relative"
           display={getListDisplayMode({
+            disabled,
             hasItemsToSelect,
             isOpen,
             showEmptyState: hasNoOptions(children),

--- a/src/components/Multiselect/Dynamic/DynamicMultiselect.tsx
+++ b/src/components/Multiselect/Dynamic/DynamicMultiselect.tsx
@@ -199,6 +199,7 @@ const DynamicMultiselectInner = <T extends Option>(
             isOpen,
             loading,
             hasItemsToSelect,
+            disabled,
             showEmptyState: hasNoOptions(children),
           })}
           className={listWrapperRecipe({ size })}

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -4,11 +4,12 @@ import {
   InputHTMLAttributes,
   ReactNode,
   forwardRef,
+  useMemo,
 } from "react";
 
 import { useFloating } from "~/hooks/useFloating";
 import { isString } from "~/utils";
-import { Box, List, PropsWithBox, Text } from "..";
+import { Box, List, PropsWithBox, Text, TextProps } from "..";
 import { HelperText, InputVariants } from "../BaseInput";
 import {
   NoOptions,
@@ -102,6 +103,18 @@ const SelectInner = <T extends Option, V extends Option | string>(
 
   const { refs, floatingStyles } = useFloating();
 
+  const labelColor = useMemo((): TextProps["color"] => {
+    if (error) {
+      return "critical1";
+    }
+
+    if (disabled) {
+      return "defaultDisabled";
+    }
+
+    return "default1";
+  }, [disabled, error]);
+
   return (
     <Box display="flex" flexDirection="column">
       <SelectWrapper
@@ -128,7 +141,7 @@ const SelectInner = <T extends Option, V extends Option | string>(
           <Text
             size={size}
             variant="body"
-            color={error ? "critical1" : "default1"}
+            color={labelColor}
             title={selectedItem?.label}
           >
             {selectedItem?.label}

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -139,7 +139,8 @@ const SelectInner = <T extends Option, V extends Option | string>(
         <Box
           position="relative"
           display={getListDisplayMode({
-            isOpen,
+            isOpen: isOpen,
+            disabled,
             hasItemsToSelect,
             showEmptyState: hasNoOptions(children),
           })}


### PR DESCRIPTION
I want to merge this change because its fixes disabled state on combobox, select and multiselect. 
Also fix disabled label color in select component.

This PR closes #...

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

- [ ] New components are exported from `./src/components/index.ts`.
- [ ] The storybook story is created and documentation is properly generated.
- [ ] New component is wrapped in `forwardRef`.
