### PR TITLE
Fix: missing script, stale bot rfc closing, chromatic branch name

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -28,12 +28,12 @@ jobs:
             - recursive: false
               args: [--frozen-lockfile]
       - name: Publish to Chromatic
-        if: github.ref != 'refs/heads/canary'
+        if: github.ref != 'refs/heads/main'
         uses: chromaui/action@a89b674adf766dbde41ad9ea2b2b60b91188a0f0 # v6.17.4
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
       - name: Publish to Chromatic and auto accept changes
-        if: github.ref == 'refs/heads/canary'
+        if: github.ref == 'refs/heads/main'
         uses: chromaui/action@a89b674adf766dbde41ad9ea2b2b60b91188a0f0 # v6.17.4
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}

--- a/.github/workflows/stale-bot.yml
+++ b/.github/workflows/stale-bot.yml
@@ -19,4 +19,4 @@ jobs:
           days-before-stale: 14
           days-before-close: 2
           exempt-pr-labels: epic,triage,bug,blocker,backlog,feature
-          exempt-issue-labels: epic,triage,bug,blocker,backlog,feature
+          exempt-issue-labels: epic,triage,bug,blocker,backlog,feature,rfc

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "test": "vitest",
     "dev": "storybook dev -p 6006",
     "dev:docs": "storybook dev -p 6006 --docs",
-    "release": "pnpm publish && pnpm exec changeset tag && git push --follow-tags",
+    "publish:ci": "pnpm publish && pnpm exec changeset tag && git push --follow-tags",
     "prepare": "is-ci || husky install",
     "chromatic": "chromatic --exit-zero-on-changes"
   },


### PR DESCRIPTION
I want to merge this change because it fixes:
* Wrong name for publish script in pkg.json
* Stalebot closing rfc issues
* Name for stalebot workflow (to be consistent with other filenames in repo)
* Chromatic branch name

This PR closes #...

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

- [ ] New components are exported from `./src/components/index.ts`.
- [ ] The storybook story is created and documentation is properly generated.
- [ ] New component is wrapped in `forwardRef`.
