### PR TITLE
Add ability to release dev tag

### DIFF
--- a/.changeset/few-countries-hope.md
+++ b/.changeset/few-countries-hope.md
@@ -1,0 +1,5 @@
+---
+"@saleor/macaw-ui": patch
+---
+
+test macaw-ui dev release

--- a/.changeset/few-countries-hope.md
+++ b/.changeset/few-countries-hope.md
@@ -1,5 +1,0 @@
----
-"@saleor/macaw-ui": patch
----
-
-test macaw-ui dev release

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -1,0 +1,48 @@
+name: Release @dev tag to npm
+on:
+  pull_request:
+    types: [labeled]
+
+jobs:
+  release:
+    if: ${{ github.event.label.name == 'release dev tag' }}
+    runs-on: ubuntu-22.04
+    env:
+      HUSKY: 0
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup PNPM
+        uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3.0.0
+        with:
+          run_install: |
+            - args: [--frozen-lockfile]
+      - name: Check for changeset
+        run: pnpm exec changeset status --since origin/main
+      - name: Create .npmrc
+        run: |
+          cat << EOF > "$HOME/.npmrc"
+            //registry.npmjs.org/:_authToken=$NPM_TOKEN
+          EOF
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Release on @dev tag in npm
+        run: pnpm publish:ci-dev
+      - name: Get new package version
+        run: |
+          VERSION=$(cat package.json | jq -r '.version')
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+      - name: Add installation instructions PR comment
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+        env:
+          VERSION: ${{ env.VERSION }}
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            Released snapshot build with `@dev` tag in npm with version: `${{ env.VERSION }}`.
+
+            Install it with:
+            ```shell
+            pnpm add @saleor/macaw-ui@${{ env.VERSION }}
+            ```

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           title: Release to npm
           commit: Release to npm
-          publish: "pnpm publish:ci"
+          publish: "pnpm publish:ci-prod"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "test": "vitest",
     "dev": "storybook dev -p 6006",
     "dev:docs": "storybook dev -p 6006 --docs",
-    "publish:ci": "pnpm publish && pnpm exec changeset tag && git push --follow-tags",
+    "publish:ci-prod": "pnpm publish && pnpm exec changeset tag && git push --follow-tags",
+    "publish:ci-dev": "pnpm exec changeset version --snapshot pr && pnpm publish --tag dev --no-git-checks",
     "prepare": "is-ci || husky install",
     "chromatic": "chromatic --exit-zero-on-changes"
   },


### PR DESCRIPTION
I want to merge this change because it adds ability to release macaw-ui as dev tag if you add label on PR.

This PR closes #...

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

- [ ] New components are exported from `./src/components/index.ts`.
- [ ] The storybook story is created and documentation is properly generated.
- [ ] New component is wrapped in `forwardRef`.
