### PR TITLE
Fix button font weights

### DIFF
--- a/.changeset/lemon-tools-tan.md
+++ b/.changeset/lemon-tools-tan.md
@@ -1,0 +1,5 @@
+---
+"@saleor/macaw-ui": patch
+---
+
+This change adds bold font weight to button component and lowers bold font weight from 700 to 600.

--- a/src/components/Button/Button.css.ts
+++ b/src/components/Button/Button.css.ts
@@ -9,6 +9,7 @@ export const button = recipe({
       placeItems: "center",
       padding: 0,
       textDecoration: "none",
+      fontWeight: "bold",
       cursor: {
         default: "pointer",
         disabled: "not-allowed",

--- a/src/theme/themes/common.ts
+++ b/src/theme/themes/common.ts
@@ -74,7 +74,7 @@ export const fontWeight = {
   light: "300",
   regular: "400",
   medium: "500",
-  bold: "700",
+  bold: "600",
 };
 
 export const letterSpacing = {


### PR DESCRIPTION
I want to merge this change because it:
- fixes default button font weight (should be bold)
- changes bold font weight to 600

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

- [ ] New components are exported from `./src/components/index.ts`.
- [ ] The storybook story is created and documentation is properly generated.
- [ ] New component is wrapped in `forwardRef`.
