### PR TITLE
Pass `data-portal-for` attr to list in portal

### DIFF
--- a/.changeset/fuzzy-brooms-travel.md
+++ b/.changeset/fuzzy-brooms-travel.md
@@ -1,0 +1,5 @@
+---
+"@saleor/macaw-ui": patch
+---
+
+ID passed to comobobox will now be passed as an attribute to dropdown list wrapper box

--- a/src/components/Combobox/Dynamic/DynamicCombobox.tsx
+++ b/src/components/Combobox/Dynamic/DynamicCombobox.tsx
@@ -155,6 +155,7 @@ const DynamicComboboxInner = <T extends Option>(
             showEmptyState: hasNoOptions(children),
           })}
           className={listWrapperRecipe({ size })}
+          data-portal-for={id}
         >
           <List
             as="ul"

--- a/src/components/Combobox/Static/Combobox.tsx
+++ b/src/components/Combobox/Static/Combobox.tsx
@@ -147,6 +147,7 @@ const ComboboxInner = <T extends Option, V extends Option | string>(
             showEmptyState: hasNoOptions(children),
           })}
           className={listWrapperRecipe({ size })}
+          data-portal-for={id}
         >
           <List
             as="ul"


### PR DESCRIPTION
I want to merge this change because it adds a `data-portal-for={id}` to combobox dropdown list box.

This PR closes #...

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

- [ ] New components are exported from `./src/components/index.ts`.
- [ ] The storybook story is created and documentation is properly generated.
- [ ] New component is wrapped in `forwardRef`.
