### PR TITLE
Change default `Skeleton` height

### DIFF
--- a/.changeset/flat-avocados-build.md
+++ b/.changeset/flat-avocados-build.md
@@ -1,0 +1,5 @@
+---
+"@saleor/macaw-ui": patch
+---
+
+Skeleton component now by default has same height as text

--- a/src/components/Skeleton/Skeleton.tsx
+++ b/src/components/Skeleton/Skeleton.tsx
@@ -15,7 +15,7 @@ export const Skeleton = ({ className, ...props }: SkeletonProps) => {
       className={classNames(skeleton, className)}
       backgroundColor="default3"
       width="100%"
-      height={1}
+      height={4}
       borderRadius={2}
       {...props}
     />

--- a/src/components/Skeleton/Skeleton.tsx
+++ b/src/components/Skeleton/Skeleton.tsx
@@ -15,7 +15,7 @@ export const Skeleton = ({ className, ...props }: SkeletonProps) => {
       className={classNames(skeleton, className)}
       backgroundColor="default3"
       width="100%"
-      height={4}
+      height={3}
       borderRadius={2}
       {...props}
     />


### PR DESCRIPTION
I want to merge this change because it improves how UI looks during loading. Skeleton now has similar height to text

This PR closes #...

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

- [ ] New components are exported from `./src/components/index.ts`.
- [ ] The storybook story is created and documentation is properly generated.
- [ ] New component is wrapped in `forwardRef`.
