### PR TITLE
Fix downshift disabled errors

### DIFF
--- a/.changeset/seven-experts-act.md
+++ b/.changeset/seven-experts-act.md
@@ -1,0 +1,5 @@
+---
+"@saleor/macaw-ui": patch
+---
+
+Macaw-ui no longer shows an error regarding disabled state of combobox items during development.

--- a/src/components/Combobox/Dynamic/DynamicCombobox.tsx
+++ b/src/components/Combobox/Dynamic/DynamicCombobox.tsx
@@ -177,7 +177,6 @@ const DynamicComboboxInner = <T extends Option>(
                   {...getItemProps({
                     item,
                     index,
-                    disabled: item.disabled,
                   })}
                   active={highlightedIndex === index}
                 >

--- a/src/components/Multiselect/Dynamic/DynamicMultiselect.tsx
+++ b/src/components/Multiselect/Dynamic/DynamicMultiselect.tsx
@@ -222,7 +222,6 @@ const DynamicMultiselectInner = <T extends Option>(
                   {...getItemProps({
                     item,
                     index,
-                    disabled: item.disabled,
                   })}
                 >
                   <Text


### PR DESCRIPTION
I want to merge this change because it fixes the following warning when using combobox:

```
Passing "disabled" as an argument to getItemProps is not supported anymore. Please use the isItemDisabled prop from useCombobox.
```

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

- [ ] New components are exported from `./src/components/index.ts`.
- [ ] The storybook story is created and documentation is properly generated.
- [ ] New component is wrapped in `forwardRef`.
