### PR TITLE
Allow passing Radix props to Dialog.Content

### DIFF
--- a/src/components/Modal/Content.tsx
+++ b/src/components/Modal/Content.tsx
@@ -6,6 +6,11 @@ import { showContent } from "./Content.css";
 export type ModalContentProps = {
   children: React.ReactNode;
   disableAutofocus?: boolean;
+  dialogContentProps?: Omit<
+    Dialog.DialogContentProps,
+    "onOpenAutoFocus" | "className" | "asChild"
+  >;
+  container?: HTMLElement | null | undefined;
 };
 
 const createAutofocusHandler = (isDisabled?: boolean) => {
@@ -18,15 +23,21 @@ const createAutofocusHandler = (isDisabled?: boolean) => {
   };
 };
 
-export const Content = ({ children, disableAutofocus }: ModalContentProps) => {
+export const Content = ({
+  children,
+  disableAutofocus,
+  container,
+  dialogContentProps,
+}: ModalContentProps) => {
   return (
-    <Dialog.Portal>
+    <Dialog.Portal container={container}>
       <Dialog.Overlay asChild className={showContent}>
         <Backdrop>
           <Dialog.Content
             asChild
             className={showContent}
             {...createAutofocusHandler(disableAutofocus)}
+            {...dialogContentProps}
           >
             {children}
           </Dialog.Content>


### PR DESCRIPTION
I want to merge this change because it allows passing custom props to Radix's `Dialog.Content` element, for example: `onPointerOutside` event handler

This PR is required for https://github.com/saleor/saleor-dashboard/pull/5432 

### Pull Request Checklist

- [ ] New components are exported from `./src/components/index.ts`.
- [ ] The storybook story is created and documentation is properly generated.
- [ ] New component is wrapped in `forwardRef`.
