### PR TITLE
Fix Chrome Extension link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ pnpm change:add
 
 ### Useful tooling
 
-- Chrome browser extension - [Atomic CSS Devtools](https://chromewebstore.google.com/detail/atomic-css-devtools)
+- Chrome browser extension - [Atomic CSS Devtools](https://chromewebstore.google.com/detail/atomic-css-devtools/cbjhfeooiomphlikkblgdageenemhpgc)
 
 ## License
 


### PR DESCRIPTION
I want to merge this change because it fixes broken link to Chrome Extension in README
