### PR TITLE
Allow `type: multiple` in accordion

### DIFF
--- a/.changeset/nice-nails-grin.md
+++ b/.changeset/nice-nails-grin.md
@@ -1,0 +1,5 @@
+---
+"@saleor/macaw-ui": patch
+---
+
+You can now pass "multiple" as type to the Accordion component.

--- a/src/components/Accordion/Root.tsx
+++ b/src/components/Accordion/Root.tsx
@@ -1,29 +1,55 @@
-import { Root as AccordionRoot } from "@radix-ui/react-accordion";
+import {
+  AccordionMultipleProps,
+  Root as AccordionRoot,
+  AccordionSingleProps,
+} from "@radix-ui/react-accordion";
 import { forwardRef, ReactNode } from "react";
 import { Box, PropsWithBox } from "../Box";
 
-export type AccordionRootProps = PropsWithBox<{
-  children: ReactNode;
-  defaultValue?: string;
-  value?: string;
-  onValueChange?: (value: string) => void;
-}>;
+export type AccordionType = "single" | "multiple";
+
+export type AccordionValue<T extends AccordionType> = T extends "single"
+  ? string
+  : string[];
+
+export type AccordionRootProps<T extends AccordionType = "single"> =
+  PropsWithBox<{
+    children: ReactNode;
+    type?: AccordionType;
+    defaultValue?: AccordionValue<T>;
+    value?: AccordionValue<T>;
+    onValueChange?: (value: AccordionValue<T>) => void;
+  }>;
 
 export const Root = forwardRef<HTMLElement, AccordionRootProps>(
-  ({ children, defaultValue, value, onValueChange, ...rest }, ref) => (
-    <AccordionRoot
-      type="single"
-      collapsible
-      defaultValue={defaultValue}
-      value={value}
-      onValueChange={onValueChange}
-      asChild
-    >
-      <Box {...rest} ref={ref} data-macaw-ui-component="Accordion">
-        {children}
-      </Box>
-    </AccordionRoot>
-  )
+  (
+    { children, defaultValue, value, onValueChange, type = "single", ...rest },
+    ref
+  ) => {
+    const props =
+      type === "single"
+        ? ({
+            type,
+            collapsible: true,
+            defaultValue,
+            value,
+            onValueChange,
+          } as AccordionSingleProps)
+        : ({
+            type,
+            defaultValue,
+            value,
+            onValueChange,
+          } as AccordionMultipleProps);
+
+    return (
+      <AccordionRoot {...props} asChild>
+        <Box {...rest} ref={ref} data-macaw-ui-component="Accordion">
+          {children}
+        </Box>
+      </AccordionRoot>
+    );
+  }
 );
 
 Root.displayName = "Accordion";


### PR DESCRIPTION
I want to merge this change because...

This PR closes #...

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

- [ ] New components are exported from `./src/components/index.ts`.
- [ ] The storybook story is created and documentation is properly generated.
- [ ] New component is wrapped in `forwardRef`.
