### PR TITLE
Allow all SVG properties for icons

### DIFF
--- a/.changeset/metal-jars-try.md
+++ b/.changeset/metal-jars-try.md
@@ -1,0 +1,5 @@
+---
+"@saleor/macaw-ui": patch
+---
+
+Icons now accept all `<svg>` element props, instead of limited set of properties (viewBox, className, size, disabled) as previously.

--- a/src/components/Icons/SVGWrapper/SVGWrapper.tsx
+++ b/src/components/Icons/SVGWrapper/SVGWrapper.tsx
@@ -6,7 +6,7 @@ import { classNames } from "~/utils";
 import { svgWrapper, SVGWrapperVariants } from "./SVGWrapper.css";
 
 export type SVGWrapperProps = SVGWrapperVariants &
-  SVGProps<SVGSVGElement> & {
+  Omit<SVGProps<SVGSVGElement>, "ref"> & {
     children: ReactNode;
     color?: Sprinkles["color"];
   };

--- a/src/components/Icons/SVGWrapper/SVGWrapper.tsx
+++ b/src/components/Icons/SVGWrapper/SVGWrapper.tsx
@@ -1,16 +1,15 @@
-import { ReactNode, forwardRef } from "react";
+import { ReactNode, SVGProps, forwardRef } from "react";
 
 import { sprinkles, Sprinkles } from "~/theme";
 import { classNames } from "~/utils";
 
 import { svgWrapper, SVGWrapperVariants } from "./SVGWrapper.css";
 
-export type SVGWrapperProps = SVGWrapperVariants & {
-  className?: string;
-  viewBox?: string;
-  children: ReactNode;
-  color?: Sprinkles["color"];
-};
+export type SVGWrapperProps = SVGWrapperVariants &
+  SVGProps<SVGSVGElement> & {
+    children: ReactNode;
+    color?: Sprinkles["color"];
+  };
 
 export const SVGWrapper = forwardRef<SVGSVGElement, SVGWrapperProps>(
   (

--- a/src/components/Multiselect/Common/Adornment.tsx
+++ b/src/components/Multiselect/Common/Adornment.tsx
@@ -1,6 +1,7 @@
 import { sprinkles } from "~/theme";
 import { classNames } from "~/utils";
 
+import { SVGWrapperProps } from "~/components/Icons/SVGWrapper";
 import { toggleIconStyle } from "../../BaseSelect";
 import { ArrowDownIcon } from "../../Icons";
 import { RenderEndAdornmentType, useMultiselect } from "./useMultiselect";
@@ -26,7 +27,9 @@ export const Adornment = ({
     <ArrowDownIcon
       className={classNames(toggleIconStyle, sprinkles({ cursor: "pointer" }))}
       size={size}
-      {...getToggleButtonProps({ disabled })}
+      // TODO: We should instead wrap icon with button for correct HTML structure
+      // this function returns handlers for <button> element not <svg>
+      {...(getToggleButtonProps({ disabled }) as SVGWrapperProps)}
     />
   );
 };


### PR DESCRIPTION
I want to merge this change because it fixes an issue where we would need to use `@ts-expect-error` or `@ts-ignore` for icons from macaw when we needed custom overrides (e.g. styles, tabIndex, etc.).

It simply allows passing all SVG element props, like so:

```ts
<GripIcon tabIndex={0} className={className} style={{ cursor: "grip" }} />
```
