### PR TITLE
Fix accordion overflow

### DIFF
--- a/.changeset/hungry-frogs-tie.md
+++ b/.changeset/hungry-frogs-tie.md
@@ -1,0 +1,5 @@
+---
+"@saleor/macaw-ui": patch
+---
+
+Fix Accordion overflow.

--- a/.changeset/hungry-frogs-tie.md
+++ b/.changeset/hungry-frogs-tie.md
@@ -2,4 +2,4 @@
 "@saleor/macaw-ui": patch
 ---
 
-Fix Accordion overflow.
+Fixed Accordion overflow issue by setting `overflow: visible` on open content to ensure content displays correctly.

--- a/src/components/Accordion/common.css.ts
+++ b/src/components/Accordion/common.css.ts
@@ -1,6 +1,12 @@
 import { keyframes, style } from "@vanilla-extract/css";
 
-export const trigger = style({});
+export const trigger = style({
+  selectors: {
+    '&[data-state="open"]': {
+      overflow: "visible",
+    },
+  },
+});
 
 export const icon = style({
   transition: "transform 300ms",

--- a/src/components/Accordion/common.css.ts
+++ b/src/components/Accordion/common.css.ts
@@ -1,12 +1,6 @@
 import { keyframes, style } from "@vanilla-extract/css";
 
-export const trigger = style({
-  selectors: {
-    '&[data-state="open"]': {
-      overflow: "visible",
-    },
-  },
-});
+export const trigger = style({});
 
 export const icon = style({
   transition: "transform 300ms",
@@ -40,6 +34,7 @@ export const content = style({
   selectors: {
     '&[data-state="open"]': {
       animation: `${slideDown} 300ms ease-out`,
+      overflow: "visible",
     },
     '&[data-state="closed"]': {
       animation: `${slideUp} 300ms ease-out`,


### PR DESCRIPTION
I want to merge this change because it fixes Accordion overflow issue by setting `overflow: visible` on open content to ensure content displays correctly.

### Before
![2025-10-02 at 10 12 54 - CleanShot@2x](https://github.com/user-attachments/assets/286d74b6-8870-4b9b-99d3-f6b8e347e630)

### After
![2025-10-02 at 10 13 17 - CleanShot@2x](https://github.com/user-attachments/assets/74aa3eca-c1e9-4957-b30d-2367147b94d9)


This PR closes #...

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

- [ ] New components are exported from `./src/components/index.ts`.
- [ ] The storybook story is created and documentation is properly generated.
- [ ] New component is wrapped in `forwardRef`.
