### PR TITLE
Add user-select: none to floating labels in form inputs

### DIFF
--- a/.changeset/bright-cups-sneeze.md
+++ b/.changeset/bright-cups-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@saleor/macaw-ui": patch
+---
+
+Fixed labels in form controls - now they are not selected by double click

--- a/src/components/BaseInput/BaseInput.css.ts
+++ b/src/components/BaseInput/BaseInput.css.ts
@@ -136,6 +136,7 @@ export const spanRecipe = recipe({
       transition: "transform 0.3s",
       transformOrigin: "left",
       transform: "translate(0, 50%) scale(1)",
+      userSelect: "none",
     }),
     sprinkles({
       color: "default2",


### PR DESCRIPTION
## Summary
- Added `user-select: none` to the floating label `<span>` in `BaseInput.css.ts` (`spanRecipe`)
- Prevents label text from being selected when users double-click inside Input, Textarea, Select, Combobox, and Multiselect components

## Test plan
- [ ] Verify in Storybook that double-clicking inside Input, Textarea, Select, Combobox, and Multiselect no longer selects the floating label text
- [ ] Verify that clicking the label area still focuses the input correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)